### PR TITLE
Send outside of workflows + send/set message type registration

### DIFF
--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -6,12 +6,10 @@ import (
 	"encoding/gob"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/url"
 	"os"
-	"reflect"
-	"runtime"
-	"sort"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -23,36 +21,6 @@ var (
 	_APP_ID                    string
 	_DEFAULT_ADMIN_SERVER_PORT = 3001
 )
-
-func computeApplicationVersion() string {
-	if len(registry) == 0 {
-		fmt.Println("DBOS: No registered workflows found, cannot compute application version")
-		return ""
-	}
-
-	// Collect all function names and sort them for consistent hashing
-	var functionNames []string
-	for fqn := range registry {
-		functionNames = append(functionNames, fqn)
-	}
-	sort.Strings(functionNames)
-
-	hasher := sha256.New()
-
-	for _, fqn := range functionNames {
-		workflowEntry := registry[fqn]
-
-		// Try to get function source location and other identifying info
-		if pc := runtime.FuncForPC(reflect.ValueOf(workflowEntry.wrappedFunction).Pointer()); pc != nil {
-			// Get the function's entry point - this reflects the actual compiled code
-			entry := pc.Entry()
-			fmt.Fprintf(hasher, "%x", entry)
-		}
-	}
-
-	return hex.EncodeToString(hasher.Sum(nil))
-
-}
 
 var workflowScheduler *cron.Cron // Global because accessed during workflow registration before the dbos singleton is initialized
 
@@ -277,4 +245,33 @@ func Shutdown() {
 		logger = nil
 	}
 	dbos = nil
+}
+
+func GetBinaryHash() (string, error) {
+	execPath, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	file, err := os.Open(execPath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func computeApplicationVersion() string {
+	hash, err := GetBinaryHash()
+	if err != nil {
+		fmt.Printf("DBOS: Failed to compute binary hash: %v\n", err)
+		return ""
+	}
+	return hash
 }

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -3,6 +3,7 @@ package dbos
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/gob"
 	"encoding/hex"
 	"fmt"
 	"log/slog"
@@ -140,6 +141,10 @@ func Initialize(inputConfig Config) error {
 
 	// Set global logger
 	logger = config.Logger
+
+	// Register types we serialize with gob
+	var t time.Time
+	gob.Register(t)
 
 	// Initialize global variables with environment variables, providing defaults if not set
 	_APP_VERSION = os.Getenv("DBOS__APPVERSION")

--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -1,9 +1,6 @@
 package dbos
 
 import (
-	"context"
-	"encoding/hex"
-	"maps"
 	"testing"
 )
 
@@ -59,29 +56,4 @@ func TestConfigValidationErrorTypes(t *testing.T) {
 			t.Fatalf("expected error message '%s', got '%s'", expectedMsg, dbosErr.Message)
 		}
 	})
-}
-func TestAppVersion(t *testing.T) {
-	if _, err := hex.DecodeString(_APP_VERSION); err != nil {
-		t.Fatalf("APP_VERSION is not a valid hex string: %v", err)
-	}
-
-	// Save the original registry content
-	originalRegistry := make(map[string]workflowRegistryEntry)
-	maps.Copy(originalRegistry, registry)
-
-	// Restore the registry after the test
-	defer func() {
-		registry = originalRegistry
-	}()
-
-	// Replace the registry and verify the hash is different
-	registry = make(map[string]workflowRegistryEntry)
-
-	WithWorkflow(func(ctx context.Context, input string) (string, error) {
-		return "new-registry-workflow-" + input, nil
-	})
-	hash2 := computeApplicationVersion()
-	if _APP_VERSION == hash2 {
-		t.Fatalf("APP_VERSION hash did not change after replacing registry")
-	}
 }

--- a/dbos/serialization_test.go
+++ b/dbos/serialization_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 )
 
 /** Test serialization and deserialization
@@ -13,6 +14,7 @@ import (
 [x] Workflow inputs/outputs
 [x] Step inputs/outputs
 [x] Direct handlers, polling handler, list workflows results, get step infos
+[x] Set/get event with user defined types
 */
 
 var (
@@ -286,6 +288,93 @@ func TestWorkflowEncoding(t *testing.T) {
 		}
 		if step.Error != nil {
 			t.Fatalf("expected step error to be nil, got %v", step.Error)
+		}
+	})
+}
+
+// UserDefinedEventData is a custom struct declared outside of any workflow
+// This struct should never appear in the signature of a function registered as a DBOS workflow
+type UserDefinedEventData struct {
+	ID      int    `json:"id"`
+	Name    string `json:"name"`
+	Details struct {
+		Description string   `json:"description"`
+		Tags        []string `json:"tags"`
+	} `json:"details"`
+}
+
+func setEventUserDefinedTypeWorkflow(ctx context.Context, input string) (string, error) {
+	// Create an instance of our user-defined type inside the workflow
+	eventData := UserDefinedEventData{
+		ID:   42,
+		Name: "test-event",
+		Details: struct {
+			Description string   `json:"description"`
+			Tags        []string `json:"tags"`
+		}{
+			Description: "This is a test event with user-defined data",
+			Tags:        []string{"test", "user-defined", "serialization"},
+		},
+	}
+
+	// SetEvent should automatically register this type with gob
+	// Note the explicit type parameter since compiler cannot infer UserDefinedEventData from string input
+	err := SetEvent(ctx, WorkflowSetEventInput[UserDefinedEventData]{Key: input, Message: eventData})
+	if err != nil {
+		return "", err
+	}
+	return "user-defined-event-set", nil
+}
+
+var setEventUserDefinedTypeWf = WithWorkflow(setEventUserDefinedTypeWorkflow)
+
+func TestSetEventSerializeUserDefinedType(t *testing.T) {
+	setupDBOS(t)
+
+	t.Run("SetEventUserDefinedType", func(t *testing.T) {
+		// Start a workflow that sets an event with a user-defined type
+		setHandle, err := setEventUserDefinedTypeWf(context.Background(), "user-defined-key")
+		if err != nil {
+			t.Fatalf("failed to start workflow with user-defined event type: %v", err)
+		}
+
+		// Wait for the workflow to complete
+		result, err := setHandle.GetResult(context.Background())
+		if err != nil {
+			t.Fatalf("failed to get result from user-defined event workflow: %v", err)
+		}
+		if result != "user-defined-event-set" {
+			t.Fatalf("expected result to be 'user-defined-event-set', got '%s'", result)
+		}
+
+		// Retrieve the event to verify it was properly serialized and can be deserialized
+		retrievedEvent, err := GetEvent[UserDefinedEventData](context.Background(), WorkflowGetEventInput{
+			TargetWorkflowID: setHandle.GetWorkflowID(),
+			Key:              "user-defined-key",
+			Timeout:          3 * time.Second,
+		})
+		if err != nil {
+			t.Fatalf("failed to get user-defined event: %v", err)
+		}
+
+		// Verify the retrieved data matches what we set
+		if retrievedEvent.ID != 42 {
+			t.Fatalf("expected ID to be 42, got %d", retrievedEvent.ID)
+		}
+		if retrievedEvent.Name != "test-event" {
+			t.Fatalf("expected Name to be 'test-event', got '%s'", retrievedEvent.Name)
+		}
+		if retrievedEvent.Details.Description != "This is a test event with user-defined data" {
+			t.Fatalf("expected Description to be 'This is a test event with user-defined data', got '%s'", retrievedEvent.Details.Description)
+		}
+		if len(retrievedEvent.Details.Tags) != 3 {
+			t.Fatalf("expected 3 tags, got %d", len(retrievedEvent.Details.Tags))
+		}
+		expectedTags := []string{"test", "user-defined", "serialization"}
+		for i, tag := range retrievedEvent.Details.Tags {
+			if tag != expectedTags[i] {
+				t.Fatalf("expected tag %d to be '%s', got '%s'", i, expectedTags[i], tag)
+			}
 		}
 	})
 }

--- a/dbos/serialization_test.go
+++ b/dbos/serialization_test.go
@@ -292,8 +292,6 @@ func TestWorkflowEncoding(t *testing.T) {
 	})
 }
 
-// UserDefinedEventData is a custom struct declared outside of any workflow
-// This struct should never appear in the signature of a function registered as a DBOS workflow
 type UserDefinedEventData struct {
 	ID      int    `json:"id"`
 	Name    string `json:"name"`
@@ -304,7 +302,6 @@ type UserDefinedEventData struct {
 }
 
 func setEventUserDefinedTypeWorkflow(ctx context.Context, input string) (string, error) {
-	// Create an instance of our user-defined type inside the workflow
 	eventData := UserDefinedEventData{
 		ID:   42,
 		Name: "test-event",
@@ -317,8 +314,6 @@ func setEventUserDefinedTypeWorkflow(ctx context.Context, input string) (string,
 		},
 	}
 
-	// SetEvent should automatically register this type with gob
-	// Note the explicit type parameter since compiler cannot infer UserDefinedEventData from string input
 	err := SetEvent(ctx, WorkflowSetEventInput[UserDefinedEventData]{Key: input, Message: eventData})
 	if err != nil {
 		return "", err
@@ -379,19 +374,10 @@ func TestSetEventSerialize(t *testing.T) {
 	})
 }
 
-// UserDefinedSendData is a custom struct for testing Send serialization
-type UserDefinedSendData struct {
-	ID      int    `json:"id"`
-	Name    string `json:"name"`
-	Details struct {
-		Description string   `json:"description"`
-		Tags        []string `json:"tags"`
-	} `json:"details"`
-}
 
 func sendUserDefinedTypeWorkflow(ctx context.Context, destinationID string) (string, error) {
 	// Create an instance of our user-defined type inside the workflow
-	sendData := UserDefinedSendData{
+	sendData := UserDefinedEventData{
 		ID:   42,
 		Name: "test-send-message",
 		Details: struct {
@@ -404,8 +390,8 @@ func sendUserDefinedTypeWorkflow(ctx context.Context, destinationID string) (str
 	}
 
 	// Send should automatically register this type with gob
-	// Note the explicit type parameter since compiler cannot infer UserDefinedSendData from string input
-	err := Send(ctx, WorkflowSendInput[UserDefinedSendData]{
+	// Note the explicit type parameter since compiler cannot infer UserDefinedEventData from string input
+	err := Send(ctx, WorkflowSendInput[UserDefinedEventData]{
 		DestinationID: destinationID,
 		Topic:         "user-defined-topic",
 		Message:       sendData,
@@ -416,9 +402,9 @@ func sendUserDefinedTypeWorkflow(ctx context.Context, destinationID string) (str
 	return "user-defined-message-sent", nil
 }
 
-func recvUserDefinedTypeWorkflow(ctx context.Context, input string) (UserDefinedSendData, error) {
+func recvUserDefinedTypeWorkflow(ctx context.Context, input string) (UserDefinedEventData, error) {
 	// Receive the user-defined type message
-	result, err := Recv[UserDefinedSendData](ctx, WorkflowRecvInput{
+	result, err := Recv[UserDefinedEventData](ctx, WorkflowRecvInput{
 		Topic:   "user-defined-topic",
 		Timeout: 3 * time.Second,
 	})

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -722,7 +722,7 @@ type WorkflowSendInput[R any] struct {
 // Send automatically registers the type of R for gob encoding
 func Send[R any](ctx context.Context, input WorkflowSendInput[R]) error {
 	var typedMessage R
-	gob.Register(typedMessage) // Register the type for gob encoding
+	gob.Register(typedMessage)
 	return dbos.systemDB.Send(ctx, workflowSendInputInternal{
 		destinationID: input.DestinationID,
 		message:       input.Message,
@@ -762,7 +762,7 @@ type WorkflowSetEventInput[R any] struct {
 // SetEvent automatically registers the type of R for gob encoding
 func SetEvent[R any](ctx context.Context, input WorkflowSetEventInput[R]) error {
 	var typedMessage R
-	gob.Register(typedMessage) // Register the type for gob encoding
+	gob.Register(typedMessage)
 	return dbos.systemDB.SetEvent(ctx, workflowSetEventInputInternal{
 		key:     input.Key,
 		message: input.Message,

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -712,14 +712,22 @@ func RunAsStep[P any, R any](ctx context.Context, fn StepFunc[P, R], input P, op
 /******* WORKFLOW COMMUNICATIONS ********/
 /****************************************/
 
-type WorkflowSendInput struct {
+type WorkflowSendInput[R any] struct {
 	DestinationID string
-	Message       any
+	Message       R
 	Topic         string
 }
 
-func Send(ctx context.Context, input WorkflowSendInput) error {
-	return dbos.systemDB.Send(ctx, input)
+// Send sends a message to another workflow.
+// Send automatically registers the type of R for gob encoding
+func Send[R any](ctx context.Context, input WorkflowSendInput[R]) error {
+	var typedMessage R
+	gob.Register(typedMessage) // Register the type for gob encoding
+	return dbos.systemDB.Send(ctx, workflowSendInputInternal{
+		destinationID: input.DestinationID,
+		message:       input.Message,
+		topic:         input.Topic,
+	})
 }
 
 type WorkflowRecvInput struct {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1355,6 +1355,15 @@ func TestSendRecv(t *testing.T) {
 		if !strings.Contains(err.Error(), expectedMessagePart) {
 			t.Fatalf("expected error message to contain %q, but got %q", expectedMessagePart, err.Error())
 		}
+
+		// Wait for the receive workflow to time out
+		result, err := receiveHandle.GetResult(context.Background())
+		if err != nil {
+			t.Fatalf("failed to get result from receive workflow: %v", err)
+		}
+		if result != "--" {
+			t.Fatalf("expected receive workflow result to be '--' (timeout), got '%s'", result)
+		}
 	})
 
 	t.Run("ConcurrentRecv", func(t *testing.T) {


### PR DESCRIPTION
- Allow standalone `Send()` and `SetEvent()`
- Hash executable for standalone versioning
- Automatically register `time.Time` for `encoding/gob`
- Make `Send` and `SetEvent` generic so we can register the message type with `encoding/gob` automatically