### PR TITLE
Toward executor objects

### DIFF
--- a/dbos/admin_server.go
+++ b/dbos/admin_server.go
@@ -25,7 +25,7 @@ type queueMetadata struct {
 	RateLimit         *RateLimiter `json:"rateLimit,omitempty"`
 }
 
-func newAdminServer(port int) *adminServer {
+func newAdminServer(dbosCtx *dbosContext, port int) *adminServer {
 	mux := http.NewServeMux()
 
 	// Health endpoint
@@ -50,7 +50,7 @@ func newAdminServer(port int) *adminServer {
 
 		getLogger().Info("Recovering workflows for executors", "executors", executorIDs)
 
-		handles, err := recoverPendingWorkflows(r.Context(), executorIDs)
+		handles, err := recoverPendingWorkflows(dbosCtx, executorIDs)
 		if err != nil {
 			getLogger().Error("Error recovering workflows", "error", err)
 			http.Error(w, fmt.Sprintf("Recovery failed: %v", err), http.StatusInternalServerError)

--- a/dbos/admin_server_test.go
+++ b/dbos/admin_server_test.go
@@ -15,23 +15,29 @@ func TestAdminServer(t *testing.T) {
 
 	t.Run("Admin server is not started by default", func(t *testing.T) {
 		// Ensure clean state
-		Shutdown()
+		if dbos != nil {
+			dbos.Shutdown()
+			dbos = nil
+		}
 
-		err := Initialize(Config{
+		executor, err := Initialize(Config{
 			DatabaseURL: databaseURL,
 			AppName:     "test-app",
 		})
 		if err != nil {
 			t.Skipf("Failed to initialize DBOS: %v", err)
 		}
-		err = Launch()
+		err = executor.Launch()
 		if err != nil {
 			t.Skipf("Failed to initialize DBOS: %v", err)
 		}
 
 		// Ensure cleanup
 		defer func() {
-			Shutdown()
+			if dbos != nil {
+			dbos.Shutdown()
+			dbos = nil
+		}
 		}()
 
 		// Give time for any startup processes
@@ -55,10 +61,13 @@ func TestAdminServer(t *testing.T) {
 	})
 
 	t.Run("Admin server endpoints", func(t *testing.T) {
-		Shutdown()
+		if dbos != nil {
+			dbos.Shutdown()
+			dbos = nil
+		}
 
 		// Launch DBOS with admin server once for all endpoint tests
-		err := Initialize(Config{
+		executor, err := Initialize(Config{
 			DatabaseURL: databaseURL,
 			AppName:     "test-app",
 			AdminServer: true,
@@ -66,14 +75,17 @@ func TestAdminServer(t *testing.T) {
 		if err != nil {
 			t.Skipf("Failed to initialize DBOS with admin server: %v", err)
 		}
-		err = Launch()
+		err = executor.Launch()
 		if err != nil {
 			t.Skipf("Failed to initialize DBOS with admin server: %v", err)
 		}
 
 		// Ensure cleanup
 		defer func() {
-			Shutdown()
+			if dbos != nil {
+			dbos.Shutdown()
+			dbos = nil
+		}
 		}()
 
 		// Give the server a moment to start

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -259,8 +259,6 @@ func (e *executor) Shutdown() {
 	if logger != nil {
 		logger = nil
 	}
-	// XX now responsiblity of the caller right?
-	e = nil
 }
 
 func GetBinaryHash() (string, error) {

--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -12,7 +12,7 @@ func TestConfigValidationErrorTypes(t *testing.T) {
 			DatabaseURL: databaseURL,
 		}
 
-		_, err := Initialize(config)
+		_, err := NewDBOSContext(config)
 		if err == nil {
 			t.Fatal("expected error when app name is missing, but got none")
 		}
@@ -37,7 +37,7 @@ func TestConfigValidationErrorTypes(t *testing.T) {
 			AppName: "test-app",
 		}
 
-		_, err := Initialize(config)
+		_, err := NewDBOSContext(config)
 		if err == nil {
 			t.Fatal("expected error when database URL is missing, but got none")
 		}

--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -12,7 +12,7 @@ func TestConfigValidationErrorTypes(t *testing.T) {
 			DatabaseURL: databaseURL,
 		}
 
-		err := Initialize(config)
+		_, err := Initialize(config)
 		if err == nil {
 			t.Fatal("expected error when app name is missing, but got none")
 		}
@@ -37,7 +37,7 @@ func TestConfigValidationErrorTypes(t *testing.T) {
 			AppName: "test-app",
 		}
 
-		err := Initialize(config)
+		_, err := Initialize(config)
 		if err == nil {
 			t.Fatal("expected error when database URL is missing, but got none")
 		}

--- a/dbos/logger_test.go
+++ b/dbos/logger_test.go
@@ -11,19 +11,22 @@ func TestLogger(t *testing.T) {
 	databaseURL := getDatabaseURL(t)
 
 	t.Run("Default logger", func(t *testing.T) {
-		err := Initialize(Config{
+		executor, err := Initialize(Config{
 			DatabaseURL: databaseURL,
 			AppName:     "test-app",
 		}) // Create executor with default logger
 		if err != nil {
 			t.Fatalf("Failed to create executor with default logger: %v", err)
 		}
-		err = Launch()
+		err = executor.Launch()
 		if err != nil {
 			t.Fatalf("Failed to launch with default logger: %v", err)
 		}
 		t.Cleanup(func() {
-			Shutdown()
+			if dbos != nil {
+			dbos.Shutdown()
+			dbos = nil
+		}
 		})
 
 		if logger == nil {
@@ -45,7 +48,7 @@ func TestLogger(t *testing.T) {
 		// Add some context to the slog logger
 		slogLogger = slogLogger.With("service", "dbos-test", "environment", "test")
 
-		err := Initialize(Config{
+		executor, err := Initialize(Config{
 			DatabaseURL: databaseURL,
 			AppName:     "test-app",
 			Logger:      slogLogger,
@@ -53,12 +56,15 @@ func TestLogger(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create executor with custom logger: %v", err)
 		}
-		err = Launch()
+		err = executor.Launch()
 		if err != nil {
 			t.Fatalf("Failed to launch with custom logger: %v", err)
 		}
 		t.Cleanup(func() {
-			Shutdown()
+			if dbos != nil {
+			dbos.Shutdown()
+			dbos = nil
+		}
 		})
 
 		if logger == nil {

--- a/dbos/logger_test.go
+++ b/dbos/logger_test.go
@@ -11,7 +11,7 @@ func TestLogger(t *testing.T) {
 	databaseURL := getDatabaseURL(t)
 
 	t.Run("Default logger", func(t *testing.T) {
-		executor, err := Initialize(Config{
+		executor, err := NewDBOSContext(Config{
 			DatabaseURL: databaseURL,
 			AppName:     "test-app",
 		}) // Create executor with default logger
@@ -23,10 +23,9 @@ func TestLogger(t *testing.T) {
 			t.Fatalf("Failed to launch with default logger: %v", err)
 		}
 		t.Cleanup(func() {
-			if dbos != nil {
-			dbos.Shutdown()
-			dbos = nil
-		}
+			if executor != nil {
+				executor.Shutdown()
+			}
 		})
 
 		if logger == nil {
@@ -48,7 +47,7 @@ func TestLogger(t *testing.T) {
 		// Add some context to the slog logger
 		slogLogger = slogLogger.With("service", "dbos-test", "environment", "test")
 
-		executor, err := Initialize(Config{
+		executor, err := NewDBOSContext(Config{
 			DatabaseURL: databaseURL,
 			AppName:     "test-app",
 			Logger:      slogLogger,
@@ -61,10 +60,9 @@ func TestLogger(t *testing.T) {
 			t.Fatalf("Failed to launch with custom logger: %v", err)
 		}
 		t.Cleanup(func() {
-			if dbos != nil {
-			dbos.Shutdown()
-			dbos = nil
-		}
+			if executor != nil {
+				executor.Shutdown()
+			}
 		})
 
 		if logger == nil {

--- a/dbos/queue.go
+++ b/dbos/queue.go
@@ -73,10 +73,7 @@ func WithMaxTasksPerIteration(maxTasks int) queueOption {
 
 // NewWorkflowQueue creates a new workflow queue with optional configuration
 func NewWorkflowQueue(name string, options ...queueOption) WorkflowQueue {
-	if dbos != nil {
-		getLogger().Warn("NewWorkflowQueue called after DBOS initialization, dynamic registration is not supported")
-		return WorkflowQueue{}
-	}
+	// TODO: Add runtime check for post-initialization registration if needed
 	if _, exists := workflowQueueRegistry[name]; exists {
 		panic(newConflictingRegistrationError(name))
 	}
@@ -102,7 +99,7 @@ func NewWorkflowQueue(name string, options ...queueOption) WorkflowQueue {
 	return q
 }
 
-func queueRunner(ctx context.Context) {
+func queueRunner(executor *dbosContext) {
 	const (
 		baseInterval    = 1.0   // Base interval in seconds
 		minInterval     = 1.0   // Minimum polling interval in seconds
@@ -122,7 +119,7 @@ func queueRunner(ctx context.Context) {
 		for queueName, queue := range workflowQueueRegistry {
 			getLogger().Debug("Processing queue", "queue_name", queueName)
 			// Call DequeueWorkflows for each queue
-			dequeuedWorkflows, err := dbos.systemDB.DequeueWorkflows(ctx, queue)
+			dequeuedWorkflows, err := executor.systemDB.DequeueWorkflows(executor.GetContext(), queue, executor.executorID, executor.applicationVersion)
 			if err != nil {
 				if pgErr, ok := err.(*pgconn.PgError); ok {
 					switch pgErr.Code {
@@ -143,7 +140,7 @@ func queueRunner(ctx context.Context) {
 			}
 			for _, workflow := range dequeuedWorkflows {
 				// Find the workflow in the registry
-				registeredWorkflow, exists := dbos.workflowRegistry[workflow.name]
+				registeredWorkflow, exists := executor.workflowRegistry[workflow.name]
 				if !exists {
 					getLogger().Error("workflow function not found in registry", "workflow_name", workflow.name)
 					continue
@@ -165,7 +162,9 @@ func queueRunner(ctx context.Context) {
 					}
 				}
 
-				_, err := registeredWorkflow.wrappedFunction(ctx, input, WithWorkflowID(workflow.id))
+				// Create a workflow context from the executor context
+				workflowCtx := executor.WithValue(context.Background(), nil)
+				_, err := registeredWorkflow.wrappedFunction(workflowCtx, input, WithWorkflowID(workflow.id))
 				if err != nil {
 					getLogger().Error("Error running queued workflow", "error", err)
 				}
@@ -187,7 +186,7 @@ func queueRunner(ctx context.Context) {
 
 		// Sleep with jittered interval, but allow early exit on context cancellation
 		select {
-		case <-ctx.Done():
+		case <-executor.GetContext().Done():
 			getLogger().Info("Queue runner stopping due to context cancellation")
 			return
 		case <-time.After(sleepDuration):

--- a/dbos/queue.go
+++ b/dbos/queue.go
@@ -143,7 +143,7 @@ func queueRunner(ctx context.Context) {
 			}
 			for _, workflow := range dequeuedWorkflows {
 				// Find the workflow in the registry
-				registeredWorkflow, exists := registry[workflow.name]
+				registeredWorkflow, exists := dbos.workflowRegistry[workflow.name]
 				if !exists {
 					getLogger().Error("workflow function not found in registry", "workflow_name", workflow.name)
 					continue

--- a/dbos/queues_test.go
+++ b/dbos/queues_test.go
@@ -257,8 +257,8 @@ func TestQueueRecovery(t *testing.T) {
 	executor := setupDBOS(t)
 
 	// Create workflows with executor
-	var recoveryStepWorkflow func(context.Context, int, ...workflowOption) (WorkflowHandle[int], error)
-	var recoveryWorkflow func(context.Context, string, ...workflowOption) (WorkflowHandle[[]int], error)
+	var recoveryStepWorkflow func(context.Context, int, ...WorkflowOption) (WorkflowHandle[int], error)
+	var recoveryWorkflow func(context.Context, string, ...WorkflowOption) (WorkflowHandle[[]int], error)
 
 	recoveryStepWorkflow = RegisterWorkflow(executor, func(ctx context.Context, i int) (int, error) {
 		recoveryStepCounter++
@@ -505,7 +505,7 @@ func TestWorkerConcurrency(t *testing.T) {
 	if startEvents[1].IsSet || startEvents[2].IsSet || startEvents[3].IsSet {
 		t.Fatal("expected only blocking workflow 1 to start, but others have started")
 	}
-	workflows, err := dbos.systemDB.ListWorkflows(context.Background(), listWorkflowsDBInput{
+	workflows, err := dbos.systemDB.ListWorkflows(context.Background(), ListWorkflowsDBInput{
 		status:    []WorkflowStatusType{WorkflowStatusEnqueued},
 		queueName: workerConcurrencyQueue.name,
 	})
@@ -529,7 +529,7 @@ func TestWorkerConcurrency(t *testing.T) {
 	if startEvents[2].IsSet || startEvents[3].IsSet {
 		t.Fatal("expected only blocking workflow 2 to start, but others have started")
 	}
-	workflows, err = dbos.systemDB.ListWorkflows(context.Background(), listWorkflowsDBInput{
+	workflows, err = dbos.systemDB.ListWorkflows(context.Background(), ListWorkflowsDBInput{
 		status:    []WorkflowStatusType{WorkflowStatusEnqueued},
 		queueName: workerConcurrencyQueue.name,
 	})
@@ -561,7 +561,7 @@ func TestWorkerConcurrency(t *testing.T) {
 		t.Fatal("expected only blocking workflow 3 to start, but workflow 4 has started")
 	}
 	// Check that only one workflow is pending
-	workflows, err = dbos.systemDB.ListWorkflows(context.Background(), listWorkflowsDBInput{
+	workflows, err = dbos.systemDB.ListWorkflows(context.Background(), ListWorkflowsDBInput{
 		status:    []WorkflowStatusType{WorkflowStatusEnqueued},
 		queueName: workerConcurrencyQueue.name,
 	})
@@ -589,7 +589,7 @@ func TestWorkerConcurrency(t *testing.T) {
 	restartQueueRunner()
 	startEvents[3].Wait()
 	// Check no workflow is enqueued
-	workflows, err = dbos.systemDB.ListWorkflows(context.Background(), listWorkflowsDBInput{
+	workflows, err = dbos.systemDB.ListWorkflows(context.Background(), ListWorkflowsDBInput{
 		status:    []WorkflowStatusType{WorkflowStatusEnqueued},
 		queueName: workerConcurrencyQueue.name,
 	})

--- a/dbos/recovery.go
+++ b/dbos/recovery.go
@@ -38,7 +38,7 @@ func recoverPendingWorkflows(ctx context.Context, executorIDs []string) ([]Workf
 			continue
 		}
 
-		registeredWorkflow, exists := registry[workflow.Name]
+		registeredWorkflow, exists := dbos.workflowRegistry[workflow.Name]
 		if !exists {
 			getLogger().Error("Workflow function not found in registry", "workflow_id", workflow.ID, "name", workflow.Name)
 			continue

--- a/dbos/recovery.go
+++ b/dbos/recovery.go
@@ -7,7 +7,7 @@ import (
 func recoverPendingWorkflows(dbosCtx *dbosContext, executorIDs []string) ([]WorkflowHandle[any], error) {
 	workflowHandles := make([]WorkflowHandle[any], 0)
 	// List pending workflows for the executors
-	pendingWorkflows, err := dbosCtx.systemDB.ListWorkflows(dbosCtx.GetContext(), listWorkflowsDBInput{
+	pendingWorkflows, err := dbosCtx.systemDB.ListWorkflows(dbosCtx.GetContext(), ListWorkflowsDBInput{
 		status:             []WorkflowStatusType{WorkflowStatusPending},
 		executorIDs:        executorIDs,
 		applicationVersion: dbosCtx.applicationVersion,
@@ -32,7 +32,7 @@ func recoverPendingWorkflows(dbosCtx *dbosContext, executorIDs []string) ([]Work
 				continue
 			}
 			if cleared {
-				workflowHandles = append(workflowHandles, &workflowPollingHandle[any]{workflowID: workflow.ID, systemDB: dbosCtx.systemDB})
+				workflowHandles = append(workflowHandles, &workflowPollingHandle[any]{workflowID: workflow.ID, dbosContext: dbosCtx})
 			}
 			continue
 		}
@@ -44,7 +44,7 @@ func recoverPendingWorkflows(dbosCtx *dbosContext, executorIDs []string) ([]Work
 		}
 
 		// Convert workflow parameters to options
-		opts := []workflowOption{
+		opts := []WorkflowOption{
 			WithWorkflowID(workflow.ID),
 		}
 		// XXX we'll figure out the exact timeout/deadline settings later

--- a/dbos/serialization_test.go
+++ b/dbos/serialization_test.go
@@ -99,7 +99,7 @@ func TestWorkflowEncoding(t *testing.T) {
 		}
 
 		// Test results from ListWorkflows
-		workflows, err := dbos.systemDB.ListWorkflows(context.Background(), listWorkflowsDBInput{
+		workflows, err := dbos.systemDB.ListWorkflows(context.Background(), ListWorkflowsDBInput{
 			workflowIDs: []string{directHandle.GetWorkflowID()},
 		})
 		if err != nil {
@@ -216,7 +216,7 @@ func TestWorkflowEncoding(t *testing.T) {
 		}
 
 		// Test results from ListWorkflows
-		workflows, err := dbos.systemDB.ListWorkflows(context.Background(), listWorkflowsDBInput{
+		workflows, err := dbos.systemDB.ListWorkflows(context.Background(), ListWorkflowsDBInput{
 			workflowIDs: []string{directHandle.GetWorkflowID()},
 		})
 		if err != nil {

--- a/dbos/serialization_test.go
+++ b/dbos/serialization_test.go
@@ -17,11 +17,6 @@ import (
 [x] Set/get event with user defined types
 */
 
-var (
-	builtinWf = WithWorkflow(encodingWorkflowBuiltinTypes)
-	structWf  = WithWorkflow(encodingWorkflowStruct)
-)
-
 // Builtin types
 func encodingStepBuiltinTypes(_ context.Context, input int) (int, error) {
 	return input, errors.New("step error")
@@ -68,7 +63,11 @@ func encodingStepStruct(ctx context.Context, input StepInputStruct) (StepOutputS
 }
 
 func TestWorkflowEncoding(t *testing.T) {
-	setupDBOS(t)
+	executor := setupDBOS(t)
+
+	// Create workflows with executor
+	builtinWf := WithWorkflow(executor, encodingWorkflowBuiltinTypes)
+	structWf := WithWorkflow(executor, encodingWorkflowStruct)
 
 	t.Run("BuiltinTypes", func(t *testing.T) {
 		// Test a workflow that uses a built-in type (string)
@@ -321,10 +320,11 @@ func setEventUserDefinedTypeWorkflow(ctx context.Context, input string) (string,
 	return "user-defined-event-set", nil
 }
 
-var setEventUserDefinedTypeWf = WithWorkflow(setEventUserDefinedTypeWorkflow)
-
 func TestSetEventSerialize(t *testing.T) {
-	setupDBOS(t)
+	executor := setupDBOS(t)
+
+	// Create workflow with executor
+	setEventUserDefinedTypeWf := WithWorkflow(executor, setEventUserDefinedTypeWorkflow)
 
 	t.Run("SetEventUserDefinedType", func(t *testing.T) {
 		// Start a workflow that sets an event with a user-defined type
@@ -374,7 +374,6 @@ func TestSetEventSerialize(t *testing.T) {
 	})
 }
 
-
 func sendUserDefinedTypeWorkflow(ctx context.Context, destinationID string) (string, error) {
 	// Create an instance of our user-defined type inside the workflow
 	sendData := UserDefinedEventData{
@@ -411,11 +410,12 @@ func recvUserDefinedTypeWorkflow(ctx context.Context, input string) (UserDefined
 	return result, err
 }
 
-var sendUserDefinedTypeWf = WithWorkflow(sendUserDefinedTypeWorkflow)
-var recvUserDefinedTypeWf = WithWorkflow(recvUserDefinedTypeWorkflow)
-
 func TestSendSerialize(t *testing.T) {
-	setupDBOS(t)
+	executor := setupDBOS(t)
+
+	// Create workflows with executor
+	sendUserDefinedTypeWf := WithWorkflow(executor, sendUserDefinedTypeWorkflow)
+	recvUserDefinedTypeWf := WithWorkflow(executor, recvUserDefinedTypeWorkflow)
 
 	t.Run("SendUserDefinedType", func(t *testing.T) {
 		// Start a receiver workflow first

--- a/dbos/utils_test.go
+++ b/dbos/utils_test.go
@@ -25,7 +25,7 @@ func getDatabaseURL(t *testing.T) string {
 }
 
 /* Test database setup */
-func setupDBOS(t *testing.T) {
+func setupDBOS(t *testing.T) DBOSExecutor {
 	t.Helper()
 
 	databaseURL := getDatabaseURL(t)
@@ -54,7 +54,7 @@ func setupDBOS(t *testing.T) {
 		t.Fatalf("failed to drop test database: %v", err)
 	}
 
-	err = Initialize(Config{
+	executor, err := Initialize(Config{
 		DatabaseURL: databaseURL,
 		AppName:     "test-app",
 	})
@@ -62,20 +62,25 @@ func setupDBOS(t *testing.T) {
 		t.Fatalf("failed to create DBOS instance: %v", err)
 	}
 
-	err = Launch()
+	err = executor.Launch()
 	if err != nil {
 		t.Fatalf("failed to launch DBOS instance: %v", err)
 	}
 
-	if dbos == nil {
+	if executor == nil {
 		t.Fatal("expected DBOS instance but got nil")
 	}
 
 	// Register cleanup to run after test completes
 	t.Cleanup(func() {
 		fmt.Println("Cleaning up DBOS instance...")
-		Shutdown()
+		if dbos != nil {
+			dbos.Shutdown()
+			dbos = nil
+		}
 	})
+
+	return executor
 }
 
 /* Event struct provides a simple synchronization primitive that can be used to signal between goroutines. */

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -116,7 +116,7 @@ func TestWorkflowsWrapping(t *testing.T) {
 
 	type testCase struct {
 		name           string
-		workflowFunc   func(context.Context, string, ...workflowOption) (any, error)
+		workflowFunc   func(context.Context, string, ...WorkflowOption) (any, error)
 		input          string
 		expectedResult any
 		expectError    bool
@@ -126,7 +126,7 @@ func TestWorkflowsWrapping(t *testing.T) {
 	tests := []testCase{
 		{
 			name: "SimpleWorkflow",
-			workflowFunc: func(ctx context.Context, input string, opts ...workflowOption) (any, error) {
+			workflowFunc: func(ctx context.Context, input string, opts ...WorkflowOption) (any, error) {
 				handle, err := simpleWf(ctx, input, opts...)
 				if err != nil {
 					return nil, err
@@ -148,7 +148,7 @@ func TestWorkflowsWrapping(t *testing.T) {
 		},
 		{
 			name: "SimpleWorkflowError",
-			workflowFunc: func(ctx context.Context, input string, opts ...workflowOption) (any, error) {
+			workflowFunc: func(ctx context.Context, input string, opts ...WorkflowOption) (any, error) {
 				handle, err := simpleWfError(ctx, input, opts...)
 				if err != nil {
 					return nil, err
@@ -161,7 +161,7 @@ func TestWorkflowsWrapping(t *testing.T) {
 		},
 		{
 			name: "SimpleWorkflowWithStep",
-			workflowFunc: func(ctx context.Context, input string, opts ...workflowOption) (any, error) {
+			workflowFunc: func(ctx context.Context, input string, opts ...WorkflowOption) (any, error) {
 				handle, err := simpleWfWithStep(ctx, input, opts...)
 				if err != nil {
 					return nil, err
@@ -174,7 +174,7 @@ func TestWorkflowsWrapping(t *testing.T) {
 		},
 		{
 			name: "SimpleWorkflowStruct",
-			workflowFunc: func(ctx context.Context, input string, opts ...workflowOption) (any, error) {
+			workflowFunc: func(ctx context.Context, input string, opts ...WorkflowOption) (any, error) {
 				handle, err := simpleWfStruct(ctx, input, opts...)
 				if err != nil {
 					return nil, err
@@ -187,7 +187,7 @@ func TestWorkflowsWrapping(t *testing.T) {
 		},
 		{
 			name: "ValueReceiverWorkflow",
-			workflowFunc: func(ctx context.Context, input string, opts ...workflowOption) (any, error) {
+			workflowFunc: func(ctx context.Context, input string, opts ...WorkflowOption) (any, error) {
 				handle, err := simpleWfValue(ctx, input, opts...)
 				if err != nil {
 					return nil, err
@@ -200,7 +200,7 @@ func TestWorkflowsWrapping(t *testing.T) {
 		},
 		{
 			name: "interfaceMethodWorkflow",
-			workflowFunc: func(ctx context.Context, input string, opts ...workflowOption) (any, error) {
+			workflowFunc: func(ctx context.Context, input string, opts ...WorkflowOption) (any, error) {
 				handle, err := simpleWfIface(ctx, input, opts...)
 				if err != nil {
 					return nil, err
@@ -213,7 +213,7 @@ func TestWorkflowsWrapping(t *testing.T) {
 		},
 		{
 			name: "GenericWorkflow",
-			workflowFunc: func(ctx context.Context, input string, opts ...workflowOption) (any, error) {
+			workflowFunc: func(ctx context.Context, input string, opts ...WorkflowOption) (any, error) {
 				// For generic workflow, we need to convert string to int for testing
 				handle, err := wfInt(ctx, "42", opts...) // FIXME for now this returns a string because sys db accepts this
 				if err != nil {
@@ -227,7 +227,7 @@ func TestWorkflowsWrapping(t *testing.T) {
 		},
 		{
 			name: "ClosureWithCapturedState",
-			workflowFunc: func(ctx context.Context, input string, opts ...workflowOption) (any, error) {
+			workflowFunc: func(ctx context.Context, input string, opts ...WorkflowOption) (any, error) {
 				handle, err := wfClose(ctx, input, opts...)
 				if err != nil {
 					return nil, err
@@ -240,7 +240,7 @@ func TestWorkflowsWrapping(t *testing.T) {
 		},
 		{
 			name: "AnonymousClosure",
-			workflowFunc: func(ctx context.Context, input string, opts ...workflowOption) (any, error) {
+			workflowFunc: func(ctx context.Context, input string, opts ...WorkflowOption) (any, error) {
 				handle, err := anonymousWf(ctx, input, opts...)
 				if err != nil {
 					return nil, err
@@ -253,7 +253,7 @@ func TestWorkflowsWrapping(t *testing.T) {
 		},
 		{
 			name: "SimpleWorkflowWithStepError",
-			workflowFunc: func(ctx context.Context, input string, opts ...workflowOption) (any, error) {
+			workflowFunc: func(ctx context.Context, input string, opts ...WorkflowOption) (any, error) {
 				handle, err := simpleWfWithStepError(ctx, input, opts...)
 				if err != nil {
 					return nil, err
@@ -666,7 +666,7 @@ func TestWorkflowRecovery(t *testing.T) {
 		}
 
 		// Using ListWorkflows, retrieve the status of the workflow
-		workflows, err := dbos.systemDB.ListWorkflows(context.Background(), listWorkflowsDBInput{
+		workflows, err := dbos.systemDB.ListWorkflows(context.Background(), ListWorkflowsDBInput{
 			workflowIDs: []string{handle1.GetWorkflowID()},
 		})
 		if err != nil {


### PR DESCRIPTION
This PR:
- Encapsulate the state of a "DBOS executor" in an interface exported by the package
- Preserves compile-time type checking by exposing package-level methods that accept a DBOS executor interface
- Attempts to keep the programming interface reasonable by creating a `DBOSContext` type which holds both DBOS executor functionalities and extends the native `context.Context` interface.

I want to allow users to replace the implementation of DBOS to fit their use case, most likely testing. For example, consider the widget store checkout workflow taken from this [sibling PR](https://github.com/dbos-inc/dbos-demo-apps/pull/335/).

A user should be able to test, roughly, like this:

```golang
func TestCheckoutWorkflow(t *testing.T) {
         ...
	dbosContextMock := mocks.NewMockDBOSContext(t)
	t.Run("Payment fails", func(t *testing.T) {
		wfID := "test-workflow-id"

		// Set expectations on what DBOS stuff that happens within the workflow
		dbosContextMock.On("GetWorkflowID").Return(wfID, nil)
		dbosContextMock.On("RunAsStep", mock.Anything, "", mock.Anything).Return(1, nil).Once()                                                          // createOrder
		dbosContextMock.On("RunAsStep", mock.Anything, "", mock.Anything).Return(true, nil).Once()                                                       // reserveInventory
		dbosContextMock.On("SetEvent", mock.Anything).Return(nil).Once()                                                                                 // Set payment event
		dbosContextMock.On("Recv", mock.Anything).Return("failed", nil).Once()                                                                           // payment status
		dbosContextMock.On("RunAsStep", mock.Anything, "", mock.Anything).Return("", nil).Once()                                                         // undoReserveInventory
		dbosContextMock.On("RunAsStep", mock.Anything, UpdateOrderStatusInput{OrderID: 1, OrderStatus: CANCELLED}, mock.Anything).Return("", nil).Once() // updateOrderStatus to CANCELLED
		dbosContextMock.On("SetEvent", mock.Anything).Return(nil).Once()                                                                                 // Set workflow event

		res, err := checkoutWorkflow(dbosContextMock, "")
		if err != nil {
			t.Fatalf("checkout workflow failed: %v", err)
		}
		if res != "" {
			t.Fatalf("expected empty result, got %s", res)
		}
		dbosContextMock.AssertExpectations(t)
	})
}
```

To achieve this, while keeping type checking (see the[ checkout workflow here](https://github.com/dbos-inc/dbos-demo-apps/pull/335/files#diff-10a27237178e0f176f8aca5eb10fd6b0318bdd8a040777da6bb76d4d0fc0e712)), this PR does two things:
- For each package-level DBOS method (e.g., `SetEvent`), add a mirror method on the DBOS "executor" interface.
- Mirror methods are "typeless": interface methods cannot be generic unless the interface is, and we don't want a generic executor.

The main issue of this approach is:
- Many methods and data structures considered "internal" to DBOS must now be exposed to the public, because they must provide an implementation of DBOSContext which implements them.
- Our wrapping logic -- decidly an "ungoly" thing to do -- is generic and returns a wrapped workflow which can be injected with a DBOSContext. The issue with this is that if the user wanted to call a wrapped workflow in their test, they'd have to mock the behavior of many internal functions (e.g., UpdateWorkflowOutcome), that they shouldn't have to know about.
- The user sees package-level methods but must mock the interface methods, leading to confusion as to how to configure mocks properly

These things can be mitigated by:
- Asking users to always call their "raw" workflow functions in the test. Not the wrapped ones
- Asking users to test their steps independently, and, in workflows, mocking `RunAsStep`
- Providing a `RunAsWorkflow` function for child workflows

None of these are an issue when users right integration tests w/Postgres. They don't have to mock anything and can create / inject real executors.

At this point I find this approach extremely cumbersome -- the exposition of so many internal methods ruins the user experience and adds immense cognitive load. We are encapsulating state at the sacrifice of users cognitive load.

Likely a better solution can be found by better separation of concerns and using more Go interfaces. Things I am considering:
- Split "executor" and "context" so that contexts can be a generically typed interface.
- Expose a Workflow interface returned at registration, with a `Run` method that can be mocked. (No more "direct function calls tho")