### PR TITLE
Move queue runner to DBOSContext + fix races & leaks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
       run: go install gotest.tools/gotestsum@latest
 
     - name: Run tests
-      run: gotestsum --format github-action
+      run: gotestsum --format github-action -- -race ./...
       working-directory: ./dbos
       env:
         PGPASSWORD: a!b@c$d()e*_,/:;=?@ff[]22

--- a/dbos/admin_server_test.go
+++ b/dbos/admin_server_test.go
@@ -144,7 +144,7 @@ func TestAdminServer(t *testing.T) {
 				endpoint:       "http://localhost:3001" + workflowQueuesMetadataPath,
 				expectedStatus: http.StatusOK,
 				validateResp: func(t *testing.T, resp *http.Response) {
-					var queueMetadata []queueMetadata
+					var queueMetadata []WorkflowQueue
 					if err := json.NewDecoder(resp.Body).Decode(&queueMetadata); err != nil {
 						t.Errorf("Failed to decode response as QueueMetadata array: %v", err)
 					}
@@ -160,8 +160,8 @@ func TestAdminServer(t *testing.T) {
 					for _, queue := range queueMetadata {
 						if queue.Name == _DBOS_INTERNAL_QUEUE_NAME { // Internal queue name
 							foundInternalQueue = true
-							if queue.Concurrency != nil {
-								t.Errorf("Expected internal queue to have no concurrency limit, but got %v", *queue.Concurrency)
+							if queue.GlobalConcurrency != nil {
+								t.Errorf("Expected internal queue to have no concurrency limit, but got %v", *queue.GlobalConcurrency)
 							}
 							if queue.WorkerConcurrency != nil {
 								t.Errorf("Expected internal queue to have no worker concurrency limit, but got %v", *queue.WorkerConcurrency)

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -5,17 +5,19 @@ import (
 	"crypto/sha256"
 	"encoding/gob"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/robfig/cron/v3"
 )
 
-var (
+const (
 	_DEFAULT_ADMIN_SERVER_PORT = 3001
 )
 
@@ -78,18 +80,17 @@ type DBOSContext interface {
 }
 
 type dbosContext struct {
-	ctx context.Context
+	ctx           context.Context
+	ctxCancelFunc context.CancelCauseFunc
 
-	launched bool
+	launched atomic.Bool
 
 	systemDB    SystemDatabase
 	adminServer *adminServer
 	config      *Config
 
-	// Queue runner context and cancel function
-	queueRunnerCtx        context.Context
-	queueRunnerCancelFunc context.CancelFunc
-	queueRunnerDone       chan struct{}
+	// Queue runner
+	queueRunner *queueRunner
 
 	// Application metadata
 	applicationVersion string
@@ -171,9 +172,11 @@ func (c *dbosContext) GetApplicationID() string {
 }
 
 func NewDBOSContext(inputConfig Config) (DBOSContext, error) {
+	ctx, cancelFunc := context.WithCancelCause(context.Background())
 	initExecutor := &dbosContext{
 		workflowsWg:      &sync.WaitGroup{},
-		ctx:              context.Background(),
+		ctx:              ctx,
+		ctxCancelFunc:    cancelFunc,
 		workflowRegistry: make(map[string]workflowRegistryEntry),
 		workflowRegMutex: &sync.RWMutex{},
 	}
@@ -207,24 +210,34 @@ func NewDBOSContext(inputConfig Config) (DBOSContext, error) {
 
 	initExecutor.applicationID = os.Getenv("DBOS__APPID")
 
+	initExecutor.logger = initExecutor.logger.With(
+		//"app_version", initExecutor.applicationVersion, // This is really verbose...
+		"executor_id", initExecutor.executorID,
+		//"app_id", initExecutor.applicationID, // This should stay internal
+	)
+
 	// Create the system database
-	systemDB, err := NewSystemDatabase(config.DatabaseURL, config.Logger)
+	systemDB, err := newSystemDatabase(initExecutor, config.DatabaseURL, initExecutor.logger)
 	if err != nil {
 		return nil, newInitializationError(fmt.Sprintf("failed to create system database: %v", err))
 	}
 	initExecutor.systemDB = systemDB
 	initExecutor.logger.Info("System database initialized")
 
+	// Initialize the queue runner and register DBOS internal queue
+	initExecutor.queueRunner = newQueueRunner()
+	NewWorkflowQueue(initExecutor, _DBOS_INTERNAL_QUEUE_NAME)
+
 	return initExecutor, nil
 }
 
 func (c *dbosContext) Launch() error {
-	if c.launched {
+	if c.launched.Load() {
 		return newInitializationError("DBOS is already launched")
 	}
 
 	// Start the system database
-	c.systemDB.Launch(context.Background())
+	c.systemDB.Launch(c)
 
 	// Start the admin server if configured
 	if c.config.AdminServer {
@@ -238,17 +251,9 @@ func (c *dbosContext) Launch() error {
 		c.adminServer = adminServer
 	}
 
-	// Create context with cancel function for queue runner
-	// FIXME: cancellation now has to go through the DBOSContext
-	ctx, cancel := context.WithCancel(c.ctx)
-	c.queueRunnerCtx = ctx
-	c.queueRunnerCancelFunc = cancel
-	c.queueRunnerDone = make(chan struct{})
-
 	// Start the queue runner in a goroutine
 	go func() {
-		defer close(c.queueRunnerDone)
-		queueRunner(c)
+		c.queueRunner.run(c)
 	}()
 	c.logger.Info("Queue runner started")
 
@@ -268,61 +273,61 @@ func (c *dbosContext) Launch() error {
 	}
 
 	c.logger.Info("DBOS initialized", "app_version", c.applicationVersion, "executor_id", c.executorID)
-	c.launched = true
+	c.launched.Store(true)
 	return nil
 }
 
+// We might consider renaming this to "Cancel" to me more idiomatic
 func (c *dbosContext) Shutdown() {
+	c.logger.Info("Shutting down DBOS context")
+
+	// Cancel the context to signal all resources to stop
+	c.ctxCancelFunc(errors.New("DBOS shutdown initiated"))
+
 	// Wait for all workflows to finish
 	c.logger.Info("Waiting for all workflows to finish")
 	c.workflowsWg.Wait()
+	c.logger.Info("All workflows completed")
 
-	if !c.launched {
-		c.logger.Warn("DBOS is not launched, nothing to shutdown")
-		return
-	}
-
-	// Cancel the context to stop the queue runner
-	if c.queueRunnerCancelFunc != nil {
-		c.logger.Info("Stopping queue runner")
-		c.queueRunnerCancelFunc()
-		// Wait for queue runner to finish
-		<-c.queueRunnerDone
-		c.logger.Info("Queue runner stopped")
-	}
-
-	if c.workflowScheduler != nil {
-		c.logger.Info("Stopping workflow scheduler")
-		ctx := c.workflowScheduler.Stop()
-		// Wait for all running jobs to complete with 5-second timeout
-		timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		select {
-		case <-ctx.Done():
-			c.logger.Info("All scheduled jobs completed")
-		case <-timeoutCtx.Done():
-			c.logger.Warn("Timeout waiting for jobs to complete", "timeout", "5s")
-		}
-	}
-
+	// Close the pool and the notification listener if started
 	if c.systemDB != nil {
 		c.logger.Info("Shutting down system database")
-		c.systemDB.Shutdown()
+		c.systemDB.Shutdown(c)
 		c.systemDB = nil
 	}
 
-	if c.adminServer != nil {
-		c.logger.Info("Shutting down admin server")
-		err := c.adminServer.Shutdown()
-		if err != nil {
-			c.logger.Error("Failed to shutdown admin server", "error", err)
-		} else {
-			c.logger.Info("Admin server shutdown complete")
-		}
-		c.adminServer = nil
-	}
+	if c.launched.Load() {
+		// Wait for queue runner to finish
+		<-c.queueRunner.completionChan
+		c.logger.Info("Queue runner completed")
 
+		if c.workflowScheduler != nil {
+			c.logger.Info("Stopping workflow scheduler")
+			ctx := c.workflowScheduler.Stop()
+			// Wait for all running jobs to complete with 5-second timeout
+			timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+
+			select {
+			case <-ctx.Done():
+				c.logger.Info("All scheduled jobs completed")
+			case <-timeoutCtx.Done():
+				c.logger.Warn("Timeout waiting for jobs to complete. Moving on", "timeout", "5s")
+			}
+		}
+
+		if c.adminServer != nil {
+			c.logger.Info("Shutting down admin server")
+			err := c.adminServer.Shutdown(c)
+			if err != nil {
+				c.logger.Error("Failed to shutdown admin server", "error", err)
+			} else {
+				c.logger.Info("Admin server shutdown complete")
+			}
+			c.adminServer = nil
+		}
+	}
+	c.launched.Store(false)
 }
 
 func GetBinaryHash() (string, error) {

--- a/dbos/serialization_test.go
+++ b/dbos/serialization_test.go
@@ -63,7 +63,7 @@ func encodingStepStruct(ctx context.Context, input StepInputStruct) (StepOutputS
 }
 
 func TestWorkflowEncoding(t *testing.T) {
-	executor := setupDBOS(t)
+	executor := setupDBOS(t, true, true)
 
 	// Register workflows with executor
 	RegisterWorkflow(executor, encodingWorkflowBuiltinTypes)
@@ -321,7 +321,7 @@ func setEventUserDefinedTypeWorkflow(ctx DBOSContext, input string) (string, err
 }
 
 func TestSetEventSerialize(t *testing.T) {
-	executor := setupDBOS(t)
+	executor := setupDBOS(t, true, true)
 
 	// Register workflow with executor
 	RegisterWorkflow(executor, setEventUserDefinedTypeWorkflow)
@@ -411,7 +411,7 @@ func recvUserDefinedTypeWorkflow(ctx DBOSContext, input string) (UserDefinedEven
 }
 
 func TestSendSerialize(t *testing.T) {
-	executor := setupDBOS(t)
+	executor := setupDBOS(t, true, true)
 
 	// Register workflows with executor
 	RegisterWorkflow(executor, sendUserDefinedTypeWorkflow)

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -85,7 +85,7 @@ func Identity[T any](dbosCtx DBOSContext, in T) (T, error) {
 }
 
 func TestWorkflowsRegistration(t *testing.T) {
-	dbosCtx := setupDBOS(t)
+	dbosCtx := setupDBOS(t, true, true)
 
 	// Setup workflows with executor
 	RegisterWorkflow(dbosCtx, simpleWorkflow)
@@ -325,7 +325,7 @@ func stepRetryWorkflow(dbosCtx DBOSContext, input string) (string, error) {
 
 // TODO: step params
 func TestSteps(t *testing.T) {
-	dbosCtx := setupDBOS(t)
+	dbosCtx := setupDBOS(t, true, true)
 
 	// Create workflows with executor
 	RegisterWorkflow(dbosCtx, stepWithinAStepWorkflow)
@@ -453,7 +453,7 @@ func TestSteps(t *testing.T) {
 
 // TODO Check timeouts behaviors for parents and children (e.g. awaited cancelled, etc)
 func TestChildWorkflow(t *testing.T) {
-	dbosCtx := setupDBOS(t)
+	dbosCtx := setupDBOS(t, true, true)
 
 	// Create child workflows with executor
 	childWf := func(dbosCtx DBOSContext, i int) (string, error) {
@@ -574,7 +574,7 @@ func idempotencyWorkflowWithStep(dbosCtx DBOSContext, input string) (int64, erro
 }
 
 func TestWorkflowIdempotency(t *testing.T) {
-	dbosCtx := setupDBOS(t)
+	dbosCtx := setupDBOS(t, true, true)
 	RegisterWorkflow(dbosCtx, idempotencyWorkflow)
 
 	t.Run("WorkflowExecutedOnlyOnce", func(t *testing.T) {
@@ -627,7 +627,7 @@ func TestWorkflowIdempotency(t *testing.T) {
 }
 
 func TestWorkflowRecovery(t *testing.T) {
-	dbosCtx := setupDBOS(t)
+	dbosCtx := setupDBOS(t, true, true)
 	RegisterWorkflow(dbosCtx, idempotencyWorkflowWithStep)
 	t.Run("RecoveryResumeWhereItLeftOff", func(t *testing.T) {
 		// Reset the global counter
@@ -729,7 +729,7 @@ func infiniteDeadLetterQueueWorkflow(ctx DBOSContext, input string) (int, error)
 	return 0, nil
 }
 func TestWorkflowDeadLetterQueue(t *testing.T) {
-	dbosCtx := setupDBOS(t)
+	dbosCtx := setupDBOS(t, true, true)
 	RegisterWorkflow(dbosCtx, deadLetterQueueWorkflow, WithMaxRetries(maxRecoveryAttempts))
 	RegisterWorkflow(dbosCtx, infiniteDeadLetterQueueWorkflow, WithMaxRetries(-1)) // A negative value means infinite retries
 
@@ -903,7 +903,8 @@ var (
 )
 
 func TestScheduledWorkflows(t *testing.T) {
-	dbosCtx := setupDBOS(t)
+	dbosCtx := setupDBOS(t, true, true)
+
 	RegisterWorkflow(dbosCtx, func(ctx DBOSContext, scheduledTime time.Time) (string, error) {
 		startTime := time.Now()
 		counter++
@@ -1098,7 +1099,7 @@ type sendRecvType struct {
 }
 
 func TestSendRecv(t *testing.T) {
-	dbosCtx := setupDBOS(t)
+	dbosCtx := setupDBOS(t, true, true)
 
 	// Register all send/recv workflows with executor
 	RegisterWorkflow(dbosCtx, sendWorkflow)
@@ -1549,7 +1550,7 @@ func getEventIdempotencyWorkflow(ctx DBOSContext, input setEventWorkflowInput) (
 }
 
 func TestSetGetEvent(t *testing.T) {
-	dbosCtx := setupDBOS(t)
+	dbosCtx := setupDBOS(t, true, true)
 
 	// Register all set/get event workflows with executor
 	RegisterWorkflow(dbosCtx, setEventWorkflow)
@@ -1877,7 +1878,7 @@ func sleepRecoveryWorkflow(dbosCtx DBOSContext, duration time.Duration) (time.Du
 }
 
 func TestSleep(t *testing.T) {
-	dbosCtx := setupDBOS(t)
+	dbosCtx := setupDBOS(t, true, true)
 	RegisterWorkflow(dbosCtx, sleepRecoveryWorkflow)
 
 	t.Run("SleepDurableRecovery", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/goleak v1.3.0 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/sync v0.15.0 // indirect
 	golang.org/x/text v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ go.opentelemetry.io/otel/trace v1.29.0 h1:J/8ZNK4XgR7a21DZUAsbF8pZ5Jcw1VhACmnYt3
 go.opentelemetry.io/otel/trace v1.29.0/go.mod h1:eHl3w0sp3paPkYstJOmAimxhiFXPg+MMTlEh3nsQgWQ=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
 golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
 golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=


### PR DESCRIPTION
- New runner struct, attached to DBOSContext. Move queue registry in runner struct.
- Queue runner cancellation managed by DBOSContext.Shutdown
- Add [go leak checker](https://github.com/uber-go/goleak) in tests
- Simplify queue metadata (call list queues on the runner)
- Fix races in the tests
- Handle context timeout in system DB `DequeueWorkflows`
- Better system DB cleanup, including notification loop cancellation