### PR TITLE
Workflow timeouts

### DIFF
--- a/dbos/admin_server_test.go
+++ b/dbos/admin_server_test.go
@@ -30,7 +30,7 @@ func TestAdminServer(t *testing.T) {
 		// Ensure cleanup
 		defer func() {
 			if ctx != nil {
-				ctx.Shutdown()
+				ctx.Cancel()
 			}
 		}()
 
@@ -73,7 +73,7 @@ func TestAdminServer(t *testing.T) {
 		// Ensure cleanup
 		defer func() {
 			if ctx != nil {
-				ctx.Shutdown()
+				ctx.Cancel()
 			}
 		}()
 

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -58,7 +58,7 @@ type DBOSContext interface {
 
 	// Context Lifecycle
 	Launch() error
-	Shutdown()
+	Cancel()
 
 	// Workflow operations
 	RunAsStep(_ DBOSContext, fn StepFunc, input any) (any, error)
@@ -315,9 +315,8 @@ func (c *dbosContext) Launch() error {
 	return nil
 }
 
-// We might consider renaming this to "Cancel" to me more idiomatic
 // TODO: shutdown should really have a timeout and return an error if it wasn't able to shutdown everything
-func (c *dbosContext) Shutdown() {
+func (c *dbosContext) Cancel() {
 	c.logger.Info("Shutting down DBOS context")
 
 	// Cancel the context to signal all resources to stop

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -368,6 +368,7 @@ func (c *dbosContext) Shutdown() {
 			c.adminServer = nil
 		}
 	}
+	c.launched.Store(false)
 }
 
 func GetBinaryHash() (string, error) {

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -154,7 +154,6 @@ func WithoutCancel(ctx DBOSContext) DBOSContext {
 		return nil
 	}
 	if dbosCtx, ok := ctx.(*dbosContext); ok {
-		// Spawn a new child context without the cancel function
 		return &dbosContext{
 			ctx:                context.WithoutCancel(dbosCtx.ctx),
 			logger:             dbosCtx.logger,
@@ -168,7 +167,6 @@ func WithoutCancel(ctx DBOSContext) DBOSContext {
 		}
 	}
 	return nil
-
 }
 
 func WithTimeout(ctx DBOSContext, timeout time.Duration) (DBOSContext, context.CancelFunc) {
@@ -176,7 +174,6 @@ func WithTimeout(ctx DBOSContext, timeout time.Duration) (DBOSContext, context.C
 		return nil, func() {}
 	}
 	if dbosCtx, ok := ctx.(*dbosContext); ok {
-		// Spawn a new child context with a deadline and a cancel function
 		newCtx, cancelFunc := context.WithTimeoutCause(dbosCtx.ctx, timeout, errors.New("DBOS context timeout"))
 		return &dbosContext{
 			ctx:                newCtx,
@@ -319,6 +316,7 @@ func (c *dbosContext) Launch() error {
 }
 
 // We might consider renaming this to "Cancel" to me more idiomatic
+// TODO: shutdown should really have a timeout and return an error if it wasn't able to shutdown everything
 func (c *dbosContext) Shutdown() {
 	c.logger.Info("Shutting down DBOS context")
 

--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -20,7 +20,7 @@ func TestConfigValidationErrorTypes(t *testing.T) {
 		}
 		defer func() {
 			if ctx != nil {
-				ctx.Shutdown()
+				ctx.Cancel()
 			}
 		}() // Clean up executor
 

--- a/dbos/logger_test.go
+++ b/dbos/logger_test.go
@@ -24,7 +24,7 @@ func TestLogger(t *testing.T) {
 		}
 		t.Cleanup(func() {
 			if dbosCtx != nil {
-				dbosCtx.Shutdown()
+				dbosCtx.Cancel()
 			}
 		})
 
@@ -62,7 +62,7 @@ func TestLogger(t *testing.T) {
 		}
 		t.Cleanup(func() {
 			if dbosCtx != nil {
-				dbosCtx.Shutdown()
+				dbosCtx.Cancel()
 			}
 		})
 

--- a/dbos/queue.go
+++ b/dbos/queue.go
@@ -192,7 +192,6 @@ func (qr *queueRunner) run(ctx *dbosContext) {
 					}
 				}
 
-				// XXX this demonstrate why contexts cannot be used globally -- the task does not inherit the context used in the program that enqueued it
 				_, err := registeredWorkflow.wrappedFunction(ctx, input, WithWorkflowID(workflow.id))
 				if err != nil {
 					ctx.logger.Error("Error running queued workflow", "error", err)

--- a/dbos/queues_test.go
+++ b/dbos/queues_test.go
@@ -2,6 +2,7 @@ package dbos
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync/atomic"
@@ -24,7 +25,7 @@ This suite tests
 [x] rate limiter
 [] queue deduplication
 [] queue priority
-[] queued workflow times out
+[x] queued workflow times out
 [] scheduled workflow enqueues another workflow
 */
 
@@ -844,4 +845,216 @@ func TestQueueRateLimiter(t *testing.T) {
 	if !queueEntriesAreCleanedUp(dbosCtx) {
 		t.Fatal("expected queue entries to be cleaned up after rate limiter test")
 	}
+}
+
+func TestQueueTimeouts(t *testing.T) {
+	dbosCtx := setupDBOS(t, true, true)
+
+	timeoutQueue := NewWorkflowQueue(dbosCtx, "timeout-queue")
+
+	queuedWaitForCancelWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		// This workflow will wait indefinitely until it is cancelled
+		<-ctx.Done()
+		if !errors.Is(ctx.Err(), context.Canceled) && !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			t.Fatalf("workflow was cancelled, but context error is not context.Canceled: %v", ctx.Err())
+		}
+		return "", ctx.Err()
+	}
+	RegisterWorkflow(dbosCtx, queuedWaitForCancelWorkflow)
+
+	enqueuedWorkflowEnqueuesATimeoutWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		// This workflow will enqueue a workflow that waits indefinitely until it is cancelled
+		handle, err := RunAsWorkflow(ctx, queuedWaitForCancelWorkflow, "enqueued-wait-for-cancel", WithQueue(timeoutQueue.Name))
+		if err != nil {
+			t.Fatalf("failed to start enqueued wait for cancel workflow: %v", err)
+		}
+		// Workflow should get AwaitedWorkflowCancelled DBOSError
+		_, err = handle.GetResult()
+		if err == nil {
+			t.Fatal("expected error when waiting for enqueued workflow to complete, but got none")
+		}
+		dbosErr, ok := err.(*DBOSError)
+		if !ok {
+			t.Fatalf("expected error to be of type *DBOSError, got %T", err)
+		}
+		if dbosErr.Code != AwaitedWorkflowCancelled {
+			t.Fatalf("expected error code to be AwaitedWorkflowCancelled, got %v", dbosErr.Code)
+		}
+		return "should-never-see-this", nil
+	}
+	RegisterWorkflow(dbosCtx, enqueuedWorkflowEnqueuesATimeoutWorkflow)
+
+	detachedWorkflow := func(ctx DBOSContext, timeout time.Duration) (string, error) {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(timeout):
+			return "detached-workflow-completed", nil
+		}
+	}
+
+	enqueuedWorkflowEnqueuesADetachedWorkflow := func(ctx DBOSContext, timeout time.Duration) (string, error) {
+		// This workflow will enqueue a workflow that is not cancelable
+		childCtx := WithoutCancel(ctx)
+		handle, err := RunAsWorkflow(childCtx, detachedWorkflow, timeout*2, WithQueue(timeoutQueue.Name))
+		if err != nil {
+			t.Fatalf("failed to start enqueued detached workflow: %v", err)
+		}
+
+		// Wait for the enqueued workflow to complete
+		result, err := handle.GetResult()
+		if err != nil {
+			t.Fatalf("failed to get result from enqueued detached workflow: %v", err)
+		}
+		if result != "detached-workflow-completed" {
+			t.Fatalf("expected result to be 'detached-workflow-completed', got '%s'", result)
+		}
+		// Check the workflow status: should be success
+		status, err := handle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get enqueued detached workflow status: %v", err)
+		}
+		if status.Status != WorkflowStatusSuccess {
+			t.Fatalf("expected enqueued detached workflow status to be WorkflowStatusSuccess, got %v", status.Status)
+		}
+		return result, nil
+	}
+
+	RegisterWorkflow(dbosCtx, detachedWorkflow)
+	RegisterWorkflow(dbosCtx, enqueuedWorkflowEnqueuesADetachedWorkflow)
+
+	dbosCtx.Launch()
+
+	t.Run("EnqueueWorkflowTimeout", func(t *testing.T) {
+		// Start a workflow that will wait indefinitely
+		cancelCtx, cancelFunc := WithTimeout(dbosCtx, 1*time.Millisecond)
+		defer cancelFunc() // Ensure we clean up the context
+
+		handle, err := RunAsWorkflow(cancelCtx, queuedWaitForCancelWorkflow, "enqueue-wait-for-cancel", WithQueue(timeoutQueue.Name))
+		if err != nil {
+			t.Fatalf("failed to enqueue wait for cancel workflow: %v", err)
+		}
+
+		// Wait for the workflow to complete and get the result
+		result, err := handle.GetResult()
+		if err == nil {
+			t.Fatal("expected error but got none")
+		}
+
+		// Check the error type
+		dbosErr, ok := err.(*DBOSError)
+		if !ok {
+			t.Fatalf("expected error to be of type *DBOSError, got %T", err)
+		}
+
+		if dbosErr.Code != AwaitedWorkflowCancelled {
+			t.Fatalf("expected error code to be AwaitedWorkflowCancelled, got %v", dbosErr.Code)
+		}
+
+		if result != "" {
+			t.Fatalf("expected result to be an empty string, got '%s'", result)
+		}
+
+		// Check the workflow status: should be cancelled
+		status, err := handle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get workflow status: %v", err)
+		}
+		if status.Status != WorkflowStatusCancelled {
+			t.Fatalf("expected workflow status to be WorkflowStatusCancelled, got %v", status.Status)
+		}
+
+		if !queueEntriesAreCleanedUp(dbosCtx) {
+			t.Fatal("expected queue entries to be cleaned up after workflow cancellation, but they are not")
+		}
+	})
+
+	t.Run("EnqueueWorkflowThatEnqueuesATimeoutWorkflow", func(t *testing.T) {
+		// Start a workflow that enqueues another workflow that waits indefinitely
+		cancelCtx, cancelFunc := WithTimeout(dbosCtx, 1*time.Millisecond)
+		defer cancelFunc() // Ensure we clean up the context
+
+		handle, err := RunAsWorkflow(cancelCtx, enqueuedWorkflowEnqueuesATimeoutWorkflow, "enqueue-timeout-workflow", WithQueue(timeoutQueue.Name))
+		if err != nil {
+			t.Fatalf("failed to start enqueued workflow: %v", err)
+		}
+
+		// Wait for the workflow to complete and get the result
+		result, err := handle.GetResult()
+		if err == nil {
+			t.Fatal("expected error but got none")
+		}
+
+		// Check the error type
+		dbosErr, ok := err.(*DBOSError)
+		if !ok {
+			t.Fatalf("expected error to be of type *DBOSError, got %T", err)
+		}
+
+		if dbosErr.Code != AwaitedWorkflowCancelled {
+			t.Fatalf("expected error code to be AwaitedWorkflowCancelled, got %v", dbosErr.Code)
+		}
+
+		if result != "" {
+			t.Fatalf("expected result to be an empty string, got '%s'", result)
+		}
+
+		// Check the workflow status: should be cancelled
+		status, err := handle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get workflow status: %v", err)
+		}
+		if status.Status != WorkflowStatusCancelled {
+			t.Fatalf("expected workflow status to be WorkflowStatusCancelled, got %v", status.Status)
+		}
+
+		if !queueEntriesAreCleanedUp(dbosCtx) {
+			t.Fatal("expected queue entries to be cleaned up after workflow cancellation, but they are not")
+		}
+	})
+
+	t.Run("EnqueueWorkflowThatEnqueuesADetachedWorkflow", func(t *testing.T) {
+		// Start a workflow that enqueues another workflow that is not cancelable
+		timeout := 100 * time.Millisecond
+		cancelCtx, cancelFunc := WithTimeout(dbosCtx, timeout)
+		defer cancelFunc() // Ensure we clean up the context
+
+		handle, err := RunAsWorkflow(cancelCtx, enqueuedWorkflowEnqueuesADetachedWorkflow, timeout, WithQueue(timeoutQueue.Name))
+		if err != nil {
+			t.Fatalf("failed to start enqueued detached workflow: %v", err)
+		}
+
+		// Wait for the workflow to complete and get the result
+		result, err := handle.GetResult()
+		if err == nil {
+			t.Fatalf("expected error but got none")
+		}
+
+		// Check the error type
+		dbosErr, ok := err.(*DBOSError)
+		if !ok {
+			t.Fatalf("expected error to be of type *DBOSError, got %T", err)
+		}
+
+		if dbosErr.Code != AwaitedWorkflowCancelled {
+			t.Fatalf("expected error code to be AwaitedWorkflowCancelled, got %v", dbosErr.Code)
+		}
+
+		if result != "" {
+			t.Fatalf("expected result to be an empty string, got '%s'", result)
+		}
+
+		// Check the workflow status: should be cancelled
+		status, err := handle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get enqueued detached workflow status: %v", err)
+		}
+		if status.Status != WorkflowStatusCancelled {
+			t.Fatalf("expected enqueued detached workflow status to be WorkflowStatusCancelled, got %v", status.Status)
+		}
+
+		if !queueEntriesAreCleanedUp(dbosCtx) {
+			t.Fatal("expected queue entries to be cleaned up after workflow completion, but they are not")
+		}
+	})
 }

--- a/dbos/queues_test.go
+++ b/dbos/queues_test.go
@@ -531,7 +531,6 @@ func TestWorkerConcurrency(t *testing.T) {
 	// Create workflow with dbosContext
 	blockingWfFunc := func(ctx DBOSContext, i int) (int, error) {
 		// Simulate a blocking operation
-		fmt.Println("Blocking workflow started", i)
 		startEvents[i].Set()
 		completeEvents[i].Wait()
 		return i, nil

--- a/dbos/recovery.go
+++ b/dbos/recovery.go
@@ -25,7 +25,7 @@ func recoverPendingWorkflows(ctx *dbosContext, executorIDs []string) ([]Workflow
 		}
 
 		if workflow.QueueName != "" {
-			cleared, err := ctx.systemDB.ClearQueueAssignment(ctx.ctx, workflow.ID)
+			cleared, err := ctx.systemDB.ClearQueueAssignment(ctx, workflow.ID)
 			if err != nil {
 				ctx.logger.Error("Error clearing queue assignment for workflow", "workflow_id", workflow.ID, "name", workflow.Name, "error", err)
 				continue

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -655,9 +655,8 @@ func (s *systemDatabase) CancelWorkflow(ctx context.Context, workflowID string) 
 	}
 
 	// Set the workflow's status to CANCELLED and started_at_epoch_ms to NULL (so it does not block the queue, if any)
-	// XXX set dedup id to null? Fix it when we implement deduplication
 	updateStatusQuery := `UPDATE dbos.workflow_status
-						  SET status = $1, updated_at = $2, started_at_epoch_ms = NULL, deduplication_id = NULL
+						  SET status = $1, updated_at = $2, started_at_epoch_ms = NULL
 						  WHERE workflow_uuid = $3`
 
 	_, err = tx.Exec(ctx, updateStatusQuery, WorkflowStatusCancelled, time.Now().UnixMilli(), workflowID)
@@ -1781,7 +1780,7 @@ func (s *systemDatabase) DequeueWorkflows(ctx context.Context, queue WorkflowQue
 	}
 
 	if len(dequeuedIDs) > 0 {
-		// fmt.Printf("[%s] attempting to dequeue %d task(s)\n", queue.Name, len(dequeuedIDs))
+		s.logger.Debug("attempting to dequeue task(s)", "queueName", queue.Name, "numTasks", len(dequeuedIDs))
 	}
 
 	// Update workflows to PENDING status and get their details

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -286,9 +286,10 @@ func (s *systemDatabase) InsertWorkflowStatus(ctx context.Context, input insertW
 		deadline = &millis
 	}
 
-	var timeoutMs int64 = 0
+	var timeoutMs *int64 = nil
 	if input.status.Timeout > 0 {
-		timeoutMs = input.status.Timeout.Milliseconds()
+		millis := input.status.Timeout.Milliseconds()
+		timeoutMs = &millis
 	}
 
 	inputString, err := serialize(input.status.Input)

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -653,10 +653,10 @@ func (s *systemDatabase) CancelWorkflow(ctx context.Context, workflowID string) 
 		return nil
 	}
 
-	// Clear queue-related fields and set the workflow's status to CANCELLED
-	// Note we leave the queue name because it is informative and won't block the queue
+	// Set the workflow's status to CANCELLED and started_at_epoch_ms to NULL (so it does not block the queue, if any)
+	// XXX set dedup id to null? Fix it when we implement deduplication
 	updateStatusQuery := `UPDATE dbos.workflow_status
-						  SET status = $1, updated_at = $2, deduplication_id = NULL, started_at_epoch_ms = NULL, priority = NULL
+						  SET status = $1, updated_at = $2, started_at_epoch_ms = NULL, deduplication_id = NULL
 						  WHERE workflow_uuid = $3`
 
 	_, err = tx.Exec(ctx, updateStatusQuery, WorkflowStatusCancelled, time.Now().UnixMilli(), workflowID)

--- a/dbos/utils_test.go
+++ b/dbos/utils_test.go
@@ -137,7 +137,7 @@ func queueEntriesAreCleanedUp(ctx DBOSContext) bool {
 	for range maxTries {
 		// Begin transaction
 		exec := ctx.(*dbosContext)
-		tx, err := exec.systemDB.(*systemDatabase).pool.Begin(context.Background())
+		tx, err := exec.systemDB.(*systemDatabase).pool.Begin(ctx)
 		if err != nil {
 			return false
 		}
@@ -149,8 +149,8 @@ func queueEntriesAreCleanedUp(ctx DBOSContext) bool {
 					AND status IN ('ENQUEUED', 'PENDING')`
 
 		var count int
-		err = tx.QueryRow(context.Background(), query, _DBOS_INTERNAL_QUEUE_NAME).Scan(&count)
-		tx.Rollback(context.Background()) // Clean up transaction
+		err = tx.QueryRow(ctx, query, _DBOS_INTERNAL_QUEUE_NAME).Scan(&count)
+		tx.Rollback(ctx) // Clean up transaction
 
 		if err != nil {
 			return false

--- a/dbos/utils_test.go
+++ b/dbos/utils_test.go
@@ -72,7 +72,7 @@ func setupDBOS(t *testing.T, dropDB bool, checkLeaks bool) DBOSContext {
 	t.Cleanup(func() {
 		dbosCtx.(*dbosContext).logger.Info("Cleaning up DBOS instance...")
 		if dbosCtx != nil {
-			dbosCtx.Shutdown()
+			dbosCtx.Cancel()
 		}
 		dbosCtx = nil
 		if checkLeaks {

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1022,7 +1022,7 @@ func RetrieveWorkflow[R any](ctx DBOSContext, workflowID string) (workflowPollin
 	if ctx == nil {
 		return workflowPollingHandle[R]{}, errors.New("dbosCtx cannot be nil")
 	}
-	workflowStatus, err := ctx.(*dbosContext).systemDB.ListWorkflows(ctx.(*dbosContext).ctx, listWorkflowsDBInput{
+	workflowStatus, err := ctx.(*dbosContext).systemDB.ListWorkflows(ctx, listWorkflowsDBInput{
 		workflowIDs: []string{workflowID},
 	})
 	if err != nil {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -11,6 +11,7 @@ Test workflow and steps features
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1072,6 +1072,8 @@ func sendIdempotencyWorkflow(ctx DBOSContext, input sendWorkflowInput) (string, 
 func receiveIdempotencyWorkflow(ctx DBOSContext, topic string) (string, error) {
 	msg, err := Recv[string](ctx, WorkflowRecvInput{Topic: topic, Timeout: 3 * time.Second})
 	if err != nil {
+		// Unlock the test in this case
+		receiveIdempotencyStartEvent.Set()
 		return "", err
 	}
 	receiveIdempotencyStartEvent.Set()

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1962,3 +1962,324 @@ func TestSleep(t *testing.T) {
 		}
 	})
 }
+
+func TestWorkflowTimeout(t *testing.T) {
+	dbosCtx := setupDBOS(t, true, true)
+
+	waitForCancelWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		// This workflow will wait indefinitely until it is cancelled
+		<-ctx.Done()
+		if !errors.Is(ctx.Err(), context.Canceled) && !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			t.Fatalf("workflow was cancelled, but context error is not context.Canceled: %v", ctx.Err())
+		}
+		return "", ctx.Err()
+	}
+
+	RegisterWorkflow(dbosCtx, waitForCancelWorkflow)
+
+	t.Run("WorkflowTimeout", func(t *testing.T) {
+		// Start a workflow that will wait indefinitely
+		cancelCtx, cancelFunc := WithTimeout(dbosCtx, 1*time.Millisecond)
+		defer cancelFunc() // Ensure we clean up the context
+		handle, err := RunAsWorkflow(cancelCtx, waitForCancelWorkflow, "wait-for-cancel")
+		if err != nil {
+			t.Fatalf("failed to start wait for cancel workflow: %v", err)
+		}
+
+		// Wait for the workflow to complete and get the result
+		result, err := handle.GetResult()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Expected deadline exceeded error, got: %v", err)
+		}
+		if result != "" {
+			t.Fatalf("expected result to be an empty string, got '%s'", result)
+		}
+
+		// Check the workflow status: should be cancelled
+		status, err := handle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get workflow status: %v", err)
+		}
+		if status.Status != WorkflowStatusCancelled {
+			t.Fatalf("expected workflow status to be WorkflowStatusCancelled, got %v", status.Status)
+		}
+	})
+
+	t.Run("ManuallyCancelWorkflow", func(t *testing.T) {
+		cancelCtx, cancelFunc := WithTimeout(dbosCtx, 5*time.Second)
+		defer cancelFunc() // Ensure we clean up the context
+		handle, err := RunAsWorkflow(cancelCtx, waitForCancelWorkflow, "manual-cancel")
+		if err != nil {
+			t.Fatalf("failed to start manual cancel workflow: %v", err)
+		}
+
+		// Cancel the workflow manually
+		cancelFunc()
+		result, err := handle.GetResult()
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled error, got: %v", err)
+		}
+		if result != "" {
+			t.Fatalf("expected result to be an empty string, got '%s'", result)
+		}
+
+		// Check the workflow status: should be cancelled
+		status, err := handle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get workflow status: %v", err)
+		}
+		if status.Status != WorkflowStatusCancelled {
+			t.Fatalf("expected workflow status to be WorkflowStatusCancelled, got %v", status.Status)
+		}
+	})
+
+	waitForCancelStep := func(ctx context.Context, _ string) (string, error) {
+		// This step will trigger cancellation of the entire workflow context
+		<-ctx.Done()
+		if !errors.Is(ctx.Err(), context.Canceled) && !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			t.Fatalf("step was cancelled, but context error is not context.Canceled: %v", ctx.Err())
+		}
+		return "", ctx.Err()
+	}
+
+	waitForCancelInStepWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		return RunAsStep(ctx, waitForCancelStep, "trigger-cancellation")
+	}
+
+	RegisterWorkflow(dbosCtx, waitForCancelInStepWorkflow)
+
+	t.Run("WorkflowWithStepTimeout", func(t *testing.T) {
+		// Start a workflow that will run a step that triggers cancellation
+		cancelCtx, cancelFunc := WithTimeout(dbosCtx, 1*time.Millisecond)
+		defer cancelFunc() // Ensure we clean up the context
+		handle, err := RunAsWorkflow(cancelCtx, waitForCancelInStepWorkflow, "wf-with-step-timeout")
+		if err != nil {
+			t.Fatalf("failed to start workflow with step timeout: %v", err)
+		}
+
+		// Wait for the workflow to complete and get the result
+		result, err := handle.GetResult()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Expected deadline exceeded error, got: %v", err)
+		}
+		if result != "" {
+			t.Fatalf("expected result to be an empty string, got '%s'", result)
+		}
+
+		// Check the workflow status: should be cancelled
+		status, err := handle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get workflow status: %v", err)
+		}
+		if status.Status != WorkflowStatusCancelled {
+			t.Fatalf("expected workflow status to be WorkflowStatusCancelled, got %v", status.Status)
+		}
+	})
+
+	shorterStepTimeoutWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		// This workflow will run a step that has a shorter timeout than the workflow itself
+		// The timeout will trigger a step error, the workflow can do whatever it wants with that error
+		stepCtx, stepCancelFunc := WithTimeout(ctx, 1*time.Millisecond)
+		defer stepCancelFunc() // Ensure we clean up the context
+		_, err := RunAsStep(stepCtx, waitForCancelStep, "short-step-timeout")
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected step to timeout, got: %v", err)
+		}
+		return "step-timed-out", nil
+	}
+	RegisterWorkflow(dbosCtx, shorterStepTimeoutWorkflow)
+
+	t.Run("ShorterStepTimeout", func(t *testing.T) {
+		// Start a workflow that runs a step with a shorter timeout than the workflow itself
+		cancelCtx, cancelFunc := WithTimeout(dbosCtx, 5*time.Second)
+		defer cancelFunc() // Ensure we clean up the context
+		handle, err := RunAsWorkflow(cancelCtx, shorterStepTimeoutWorkflow, "shorter-step-timeout")
+		if err != nil {
+			t.Fatalf("failed to start shorter step timeout workflow: %v", err)
+		}
+		// Wait for the workflow to complete and get the result
+		result, err := handle.GetResult()
+		if err != nil {
+			t.Fatalf("failed to get result from shorter step timeout workflow: %v", err)
+		}
+		if result != "step-timed-out" {
+			t.Fatalf("expected result to be 'step-timed-out', got '%s'", result)
+		}
+		// Status is SUCCESS
+		status, err := handle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get workflow status: %v", err)
+		}
+		if status.Status != WorkflowStatusSuccess {
+			t.Fatalf("expected workflow status to be WorkflowStatusSuccess, got %v", status.Status)
+		}
+	})
+
+	detachedStep := func(ctx context.Context, timeout time.Duration) (string, error) {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(timeout):
+		}
+		return "detached-step-completed", nil
+	}
+
+	detachedStepWorkflow := func(ctx DBOSContext, timeout time.Duration) (string, error) {
+		// This workflow will run a step that is not cancelable.
+		// What this means is the workflow *will* be cancelled, but the step will run normally
+		stepCtx := WithoutCancel(ctx)
+		res, err := RunAsStep(stepCtx, detachedStep, timeout*2)
+		if err != nil {
+			t.Fatalf("failed to run detached step: %v", err)
+		}
+		if res != "detached-step-completed" {
+			t.Fatalf("expected detached step result to be 'detached-step-completed', got '%s'", res)
+		}
+		return res, nil
+	}
+	RegisterWorkflow(dbosCtx, detachedStepWorkflow)
+
+	t.Run("DetachedStepWorkflow", func(t *testing.T) {
+		// Start a workflow that runs a step that is not cancelable
+		cancelCtx, cancelFunc := WithTimeout(dbosCtx, 1*time.Millisecond)
+		defer cancelFunc() // Ensure we clean up the context
+
+		handle, err := RunAsWorkflow(cancelCtx, detachedStepWorkflow, 1*time.Second)
+		if err != nil {
+			t.Fatalf("failed to start detached step workflow: %v", err)
+		}
+		// Wait for the workflow to complete and get the result
+		result, err := handle.GetResult()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Expected deadline exceeded error, got: %v", err)
+		}
+		if result != "detached-step-completed" {
+			t.Fatalf("expected result to be 'detached-step-completed', got '%s'", result)
+		}
+		// Check the workflow status: should be cancelled
+		status, err := handle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get workflow status: %v", err)
+		}
+		if status.Status != WorkflowStatusCancelled {
+			t.Fatalf("expected workflow status to be WorkflowStatusCancelled, got %v", status.Status)
+		}
+	})
+
+	waitForCancelParent := func(ctx DBOSContext, _ string) (string, error) {
+		// This workflow will run a child workflow that waits indefinitely until it is cancelled
+		childHandle, err := RunAsWorkflow(ctx, waitForCancelWorkflow, "child-wait-for-cancel")
+		if err != nil {
+			t.Fatalf("failed to start child workflow: %v", err)
+		}
+
+		// Wait for the child workflow to complete
+		result, err := childHandle.GetResult()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected child workflow to be cancelled, got: %v", err)
+		}
+		// Check the child workflow status: should be cancelled
+		status, err := childHandle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get child workflow status: %v", err)
+		}
+		if status.Status != WorkflowStatusCancelled {
+			t.Fatalf("expected child workflow status to be WorkflowStatusCancelled, got %v", status.Status)
+		}
+		return result, nil
+	}
+
+	RegisterWorkflow(dbosCtx, waitForCancelParent)
+
+	t.Run("ChildWorkflowTimesout", func(t *testing.T) {
+		// Start a parent workflow that runs a child workflow that waits indefinitely
+		cancelCtx, cancelFunc := WithTimeout(dbosCtx, 1*time.Millisecond)
+		defer cancelFunc() // Ensure we clean up the context
+
+		handle, err := RunAsWorkflow(cancelCtx, waitForCancelParent, "parent-wait-for-child-cancel")
+		if err != nil {
+			t.Fatalf("failed to start parent workflow: %v", err)
+		}
+
+		// Wait for the parent workflow to complete and get the result
+		result, err := handle.GetResult()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Expected deadline exceeded error, got: %v", err)
+		}
+		if result != "" {
+			t.Fatalf("expected result to be an empty string, got '%s'", result)
+		}
+
+		// Check the workflow status: should be cancelled
+		status, err := handle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get workflow status: %v", err)
+		}
+		if status.Status != WorkflowStatusCancelled {
+			t.Fatalf("expected workflow status to be WorkflowStatusCancelled, got %v", status.Status)
+		}
+	})
+
+	detachedChild := func(ctx DBOSContext, timeout time.Duration) (string, error) {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(timeout):
+		}
+		return "detached-step-completed", nil
+	}
+
+	detachedChildWorkflowParent := func(ctx DBOSContext, timeout time.Duration) (string, error) {
+		childCtx := WithoutCancel(ctx)
+		childHandle, err := RunAsWorkflow(childCtx, detachedChild, timeout*2)
+		if err != nil {
+			t.Fatalf("failed to start child workflow: %v", err)
+		}
+
+		// Wait for the child workflow to complete
+		result, err := childHandle.GetResult()
+		if err != nil {
+			t.Fatalf("failed to get result from child workflow: %v", err)
+		}
+		// Check the child workflow status: should be cancelled
+		status, err := childHandle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get child workflow status: %v", err)
+		}
+		if status.Status != WorkflowStatusSuccess {
+			t.Fatalf("expected child workflow status to be WorkflowStatusSuccess, got %v", status.Status)
+		}
+		return result, nil
+	}
+
+	RegisterWorkflow(dbosCtx, detachedChild)
+	RegisterWorkflow(dbosCtx, detachedChildWorkflowParent)
+
+	t.Run("ChildWorkflowDetached", func(t *testing.T) {
+		timeout := 500 * time.Millisecond
+		cancelCtx, cancelFunc := WithTimeout(dbosCtx, timeout)
+		defer cancelFunc()
+		handle, err := RunAsWorkflow(cancelCtx, detachedChildWorkflowParent, timeout)
+		if err != nil {
+			t.Fatalf("failed to start parent workflow with detached child: %v", err)
+		}
+
+		// Wait for the parent workflow to complete and get the result
+		result, err := handle.GetResult()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Expected deadline exceeded error, got: %v", err)
+		}
+		if result != "detached-step-completed" {
+			t.Fatalf("expected result to be 'detached-step-completed', got '%s'", result)
+		}
+
+		// Check the workflow status: should be cancelled
+		status, err := handle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get workflow status: %v", err)
+		}
+		if status.Status != WorkflowStatusCancelled {
+			t.Fatalf("expected workflow status to be WorkflowStatusCancelled, got %v", status.Status)
+		}
+	})
+}

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1974,7 +1974,6 @@ func TestWorkflowTimeout(t *testing.T) {
 		}
 		return "", ctx.Err()
 	}
-
 	RegisterWorkflow(dbosCtx, waitForCancelWorkflow)
 
 	t.Run("WorkflowTimeout", func(t *testing.T) {
@@ -2045,7 +2044,6 @@ func TestWorkflowTimeout(t *testing.T) {
 	waitForCancelInStepWorkflow := func(ctx DBOSContext, _ string) (string, error) {
 		return RunAsStep(ctx, waitForCancelStep, "trigger-cancellation")
 	}
-
 	RegisterWorkflow(dbosCtx, waitForCancelInStepWorkflow)
 
 	t.Run("WorkflowWithStepTimeout", func(t *testing.T) {
@@ -2188,7 +2186,6 @@ func TestWorkflowTimeout(t *testing.T) {
 		}
 		return result, nil
 	}
-
 	RegisterWorkflow(dbosCtx, waitForCancelParent)
 
 	t.Run("ChildWorkflowTimesout", func(t *testing.T) {
@@ -2228,6 +2225,7 @@ func TestWorkflowTimeout(t *testing.T) {
 		}
 		return "detached-step-completed", nil
 	}
+	RegisterWorkflow(dbosCtx, detachedChild)
 
 	detachedChildWorkflowParent := func(ctx DBOSContext, timeout time.Duration) (string, error) {
 		childCtx := WithoutCancel(ctx)
@@ -2251,8 +2249,6 @@ func TestWorkflowTimeout(t *testing.T) {
 		}
 		return result, nil
 	}
-
-	RegisterWorkflow(dbosCtx, detachedChild)
 	RegisterWorkflow(dbosCtx, detachedChildWorkflowParent)
 
 	t.Run("ChildWorkflowDetached", func(t *testing.T) {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1970,7 +1970,7 @@ func TestWorkflowTimeout(t *testing.T) {
 		// This workflow will wait indefinitely until it is cancelled
 		<-ctx.Done()
 		if !errors.Is(ctx.Err(), context.Canceled) && !errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			t.Fatalf("workflow was cancelled, but context error is not context.Canceled: %v", ctx.Err())
+			t.Fatalf("workflow was cancelled, but context error is not context.Canceled nor context.DeadlineExceeded: %v", ctx.Err())
 		}
 		return "", ctx.Err()
 	}
@@ -2036,7 +2036,7 @@ func TestWorkflowTimeout(t *testing.T) {
 		// This step will trigger cancellation of the entire workflow context
 		<-ctx.Done()
 		if !errors.Is(ctx.Err(), context.Canceled) && !errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			t.Fatalf("step was cancelled, but context error is not context.Canceled: %v", ctx.Err())
+			t.Fatalf("step was cancelled, but context error is not context.Canceled nor context.DeadlineExceeded: %v", ctx.Err())
 		}
 		return "", ctx.Err()
 	}


### PR DESCRIPTION
**Design**
This PR brings native Go cancellation facilities to workflows. Users can set a timeout, using `WithTimeout`, to a `DBOSContext` passed to `RunAsWorkflow`.
When the context is cancelled (either due to a timeout or a manual cancellation), DBOS cancellation logic (cancel the workflow in Postgres) will be triggered.
When the workflow runs or is enqueued for the first time, the deadline will be persisted in Postgres.
During recovery, we will recompute the deadline from the value stored in the database and configure the workflow context accordingly.

Details:
- Inside `RunAsWorkflow`, we create an uncancellable context to run DBOS operations and configure the handler. This allows the timeout to apply only to the user function and provide an ergonomic behavior with the handle. (The handle does not "expire", for instance.)
- Because cancellation != preemption, and user functions can run without accounting for the cancellation signal, we make sure to always record their outcome, even if they were cancelled. This does not change their `CANCELLED` status.


Tests:
    [x] workflow timeout
    [x] workflow manual cancellation
    [x] workflow with steps:
        - [x] wait for cancel inside the step triggers workflow cancel
        - [x] shorter deadline can be set for the stepCtx -- parent can handle it as it wishes
        - [x] step can be detached -- workflow still times out
    [x] child workflows
        - [x] child times out: parent gets to handle the error and decide what to do
        - [x] child is detached: status success but parent is cancelled
    [x] queues
        - [x] enqueued workflow times out
        - [x] enqueued workflow that has enqueues another workflow times out (both time out)
        - [x] enqueued workflow enqueues a detached workflow (parent times out, not child)
    [x] recovery