### PR TITLE
accept a closure in RunAsStep

### DIFF
--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -61,7 +61,7 @@ type DBOSContext interface {
 	Cancel()
 
 	// Workflow operations
-	RunAsStep(_ DBOSContext, fn StepFunc, input any) (any, error)
+	RunAsStep(_ DBOSContext, fn StepFunc) (any, error)
 	RunAsWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opts ...WorkflowOption) (WorkflowHandle[any], error)
 	Send(_ DBOSContext, input WorkflowSendInputInternal) error
 	Recv(_ DBOSContext, input WorkflowRecvInput) (any, error)

--- a/dbos/queues_test.go
+++ b/dbos/queues_test.go
@@ -30,14 +30,16 @@ This suite tests
 */
 
 func queueWorkflow(ctx DBOSContext, input string) (string, error) {
-	step1, err := RunAsStep(ctx, queueStep, input)
+	step1, err := RunAsStep[string](ctx, func(context context.Context) (string, error) {
+		return queueStep(context, input)
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to run step: %v", err)
 	}
 	return step1, nil
 }
 
-func queueStep(ctx context.Context, input string) (string, error) {
+func queueStep(_ context.Context, input string) (string, error) {
 	return input, nil
 }
 

--- a/dbos/serialization_test.go
+++ b/dbos/serialization_test.go
@@ -23,7 +23,9 @@ func encodingStepBuiltinTypes(_ context.Context, input int) (int, error) {
 }
 
 func encodingWorkflowBuiltinTypes(ctx DBOSContext, input string) (string, error) {
-	stepResult, err := RunAsStep(ctx, encodingStepBuiltinTypes, 123)
+	stepResult, err := RunAsStep[int](ctx, func(context context.Context) (int, error) {
+		return encodingStepBuiltinTypes(context, 123)
+	})
 	return fmt.Sprintf("%d", stepResult), fmt.Errorf("workflow error: %v", err)
 }
 
@@ -49,13 +51,15 @@ type SimpleStruct struct {
 }
 
 func encodingWorkflowStruct(ctx DBOSContext, input WorkflowInputStruct) (StepOutputStruct, error) {
-	return RunAsStep(ctx, encodingStepStruct, StepInputStruct{
-		A: input.A,
-		B: fmt.Sprintf("%d", input.B),
+	return RunAsStep[StepOutputStruct](ctx, func(context context.Context) (StepOutputStruct, error) {
+		return encodingStepStruct(context, StepInputStruct{
+			A: input.A,
+			B: fmt.Sprintf("%d", input.B),
+		})
 	})
 }
 
-func encodingStepStruct(ctx context.Context, input StepInputStruct) (StepOutputStruct, error) {
+func encodingStepStruct(_ context.Context, input StepInputStruct) (StepOutputStruct, error) {
 	return StepOutputStruct{
 		A: input,
 		B: "processed by encodingStepStruct",

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -744,7 +744,7 @@ func RunAsStep[P any, R any](ctx DBOSContext, fn GenericStepFunc[R]) (R, error) 
 	typeErasedFn := StepFunc(func(ctx context.Context) (any, error) { return fn(ctx) })
 	typeErasedStepNameToStepName[runtime.FuncForPC(reflect.ValueOf(typeErasedFn).Pointer()).Name()] = stepName
 
-	// Call the executor method
+	// Call the executor method and pass through the result/error
 	result, err := ctx.RunAsStep(ctx, typeErasedFn)
 	// Step function could return a nil result
 	if result == nil {
@@ -755,7 +755,7 @@ func RunAsStep[P any, R any](ctx DBOSContext, fn GenericStepFunc[R]) (R, error) 
 	if !ok {
 		return *new(R), fmt.Errorf("unexpected result type: expected %T, got %T", *new(R), result)
 	}
-	return typedResult, nil
+	return typedResult, err
 }
 
 func (c *dbosContext) RunAsStep(_ DBOSContext, fn StepFunc) (any, error) {

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -684,8 +684,8 @@ func (c *dbosContext) RunAsWorkflow(_ DBOSContext, fn WorkflowFunc, input any, o
 /******* STEP FUNCTIONS *******/
 /******************************/
 
-type StepFunc func(ctx context.Context, input any) (any, error)
-type GenericStepFunc[P any, R any] func(ctx context.Context, input P) (R, error)
+type StepFunc func(ctx context.Context) (any, error)
+type GenericStepFunc[R any] func(ctx context.Context) (R, error)
 
 const StepParamsKey DBOSContextKey = "stepParams"
 
@@ -729,7 +729,7 @@ func setStepParamDefaults(params *StepParams, stepName string) *StepParams {
 
 var typeErasedStepNameToStepName = make(map[string]string)
 
-func RunAsStep[P any, R any](ctx DBOSContext, fn GenericStepFunc[P, R], input P) (R, error) {
+func RunAsStep[P any, R any](ctx DBOSContext, fn GenericStepFunc[R]) (R, error) {
 	if ctx == nil {
 		return *new(R), newStepExecutionError("", "", "ctx cannot be nil")
 	}
@@ -738,37 +738,27 @@ func RunAsStep[P any, R any](ctx DBOSContext, fn GenericStepFunc[P, R], input P)
 		return *new(R), newStepExecutionError("", "", "step function cannot be nil")
 	}
 
-	// Type-erase the function based on its actual type
-	typeErasedFn := StepFunc(func(ctx context.Context, input any) (any, error) {
-		typedInput, ok := input.(P)
-		if !ok {
-			return nil, newStepExecutionError("", "", fmt.Sprintf("unexpected input type: expected %T, got %T", *new(P), input))
-		}
-		return fn(ctx, typedInput)
-	})
+	stepName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
 
-	typeErasedStepNameToStepName[runtime.FuncForPC(reflect.ValueOf(typeErasedFn).Pointer()).Name()] = runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	// Type-erase the function
+	typeErasedFn := StepFunc(func(ctx context.Context) (any, error) { return fn(ctx) })
+	typeErasedStepNameToStepName[runtime.FuncForPC(reflect.ValueOf(typeErasedFn).Pointer()).Name()] = stepName
 
 	// Call the executor method
-	result, err := ctx.RunAsStep(ctx, typeErasedFn, input)
-	if err != nil {
-		// In case the errors comes from the DBOS step logic, the result will be nil and we must handle it
-		if result == nil {
-			return *new(R), err
-		}
-		return result.(R), err
+	result, err := ctx.RunAsStep(ctx, typeErasedFn)
+	// Step function could return a nil result
+	if result == nil {
+		return *new(R), err
 	}
-
-	// Type-check and cast the result
+	// Otherwise type-check and cast the result
 	typedResult, ok := result.(R)
 	if !ok {
 		return *new(R), fmt.Errorf("unexpected result type: expected %T, got %T", *new(R), result)
 	}
-
 	return typedResult, nil
 }
 
-func (c *dbosContext) RunAsStep(_ DBOSContext, fn StepFunc, input any) (any, error) {
+func (c *dbosContext) RunAsStep(_ DBOSContext, fn StepFunc) (any, error) {
 	// Get workflow state from context
 	wfState, ok := c.Value(workflowStateKey).(*workflowState)
 	if !ok || wfState == nil {
@@ -776,8 +766,8 @@ func (c *dbosContext) RunAsStep(_ DBOSContext, fn StepFunc, input any) (any, err
 		return nil, newStepExecutionError("", "", "workflow state not found in context: are you running this step within a workflow?")
 	}
 
+	// This should not happen when called from the package-level RunAsStep
 	if fn == nil {
-		// TODO: try to print step name
 		return nil, newStepExecutionError(wfState.workflowID, "", "step function cannot be nil")
 	}
 
@@ -790,7 +780,7 @@ func (c *dbosContext) RunAsStep(_ DBOSContext, fn StepFunc, input any) (any, err
 
 	// If within a step, just run the function directly
 	if wfState.isWithinStep {
-		return fn(c, input)
+		return fn(c)
 	}
 
 	// Setup step state
@@ -819,7 +809,7 @@ func (c *dbosContext) RunAsStep(_ DBOSContext, fn StepFunc, input any) (any, err
 	// Spawn a child DBOSContext with the step state
 	stepCtx := WithValue(c, workflowStateKey, &stepState)
 
-	stepOutput, stepError := fn(stepCtx, input)
+	stepOutput, stepError := fn(stepCtx)
 
 	// Retry if MaxRetries > 0 and the first execution failed
 	var joinedErrors error
@@ -845,7 +835,7 @@ func (c *dbosContext) RunAsStep(_ DBOSContext, fn StepFunc, input any) (any, err
 			}
 
 			// Execute the retry
-			stepOutput, stepError = fn(stepCtx, input)
+			stepOutput, stepError = fn(stepCtx)
 
 			// If successful, break
 			if stepError == nil {


### PR DESCRIPTION
This version of a more flexible `RunAsStep` interface accepts a closure which only requires a context as first argument:

`type GenericStepFunc[R any] func(ctx context.Context) (R, error)`

User must pass the input type to `RunAsStep` (the compiler cannot infer the type from the closure)

Example usage:

```
stepCtx, stepCancelFunc := WithTimeout(ctx, 1*time.Millisecond)
defer stepCancelFunc() // Ensure we clean up the context
_, err := RunAsStep[string](stepCtx, func(context context.Context) (string, error) {
    return waitForCancelStep(context)
}) 
```

The part that's tricky is that we can't use the outer scope context in the step (here, the call to `waitForCancel`)

This is because we do some context augmentation inside DBOS. And we need to pass our new context to the function.