### PR TITLE
DBOS "client context"

### DIFF
--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -362,7 +362,6 @@ func TestCancelResume(t *testing.T) {
 
 		// Try to resume a non-existent workflow
 		_, err := ResumeWorkflow[int](clientCtx, nonExistentWorkflowID)
-		fmt.Println(err)
 		if err == nil {
 			t.Fatal("expected error when resuming non-existent workflow, but got none")
 		}

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -504,7 +504,11 @@ func TestForkWorkflow(t *testing.T) {
 			t.Logf("Forking at step %d", step)
 
 			customForkedWorkflowID := fmt.Sprintf("forked-workflow-step-%d", step)
-			forkedHandle, err := ForkWorkflow[string](clientCtx, originalWorkflowID, WithForkWorkflowID(customForkedWorkflowID), WithForkStartStep(uint(step-1)))
+			forkedHandle, err := ForkWorkflow[string](clientCtx, ForkWorkflowInput{
+				OriginalWorkflowID: originalWorkflowID,
+				ForkedWorkflowID:   customForkedWorkflowID,
+				StartStep:          uint(step - 1),
+			})
 			if err != nil {
 				t.Fatalf("failed to fork workflow at step %d: %v", step, err)
 			}
@@ -575,7 +579,10 @@ func TestForkWorkflow(t *testing.T) {
 		nonExistentWorkflowID := "non-existent-workflow-for-fork"
 
 		// Try to fork a non-existent workflow
-		_, err := clientCtx.ForkWorkflow(clientCtx, nonExistentWorkflowID, WithForkStartStep(1))
+		_, err := clientCtx.ForkWorkflow(clientCtx, ForkWorkflowInput{
+			OriginalWorkflowID: nonExistentWorkflowID,
+			StartStep:          1,
+		})
 		if err == nil {
 			t.Fatal("expected error when forking non-existent workflow, but got none")
 		}
@@ -617,7 +624,10 @@ func TestForkWorkflow(t *testing.T) {
 		}
 
 		// Try to fork at step 999 (beyond workflow's actual steps)
-		_, err = clientCtx.ForkWorkflow(clientCtx, originalWorkflowID, WithForkStartStep(999))
+		_, err = clientCtx.ForkWorkflow(clientCtx, ForkWorkflowInput{
+			OriginalWorkflowID: originalWorkflowID,
+			StartStep:          999,
+		})
 		if err == nil {
 			t.Fatal("expected error when forking at step 999, but got none")
 		}

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -739,7 +739,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 1: List all workflows (no filters)
-		allWorkflows, err := ListWorkflows(clientCtx)
+		allWorkflows, err := clientCtx.ListWorkflows()
 		if err != nil {
 			t.Fatalf("failed to list all workflows: %v", err)
 		}
@@ -749,7 +749,7 @@ func TestListWorkflows(t *testing.T) {
 
 		// Test 2: Filter by workflow IDs
 		expectedIDs := workflowIDs[:3]
-		specificWorkflows, err := ListWorkflows(clientCtx, WithWorkflowIDs(expectedIDs))
+		specificWorkflows, err := clientCtx.ListWorkflows(WithWorkflowIDs(expectedIDs))
 		if err != nil {
 			t.Fatalf("failed to list workflows by IDs: %v", err)
 		}
@@ -768,7 +768,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 3: Filter by workflow ID prefix
-		batchWorkflows, err := ListWorkflows(clientCtx, WithWorkflowIDPrefix("test-batch-"))
+		batchWorkflows, err := clientCtx.ListWorkflows(WithWorkflowIDPrefix("test-batch-"))
 		if err != nil {
 			t.Fatalf("failed to list workflows by prefix: %v", err)
 		}
@@ -783,7 +783,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 4: Filter by status - SUCCESS
-		successWorkflows, err := ListWorkflows(clientCtx,
+		successWorkflows, err := clientCtx.ListWorkflows(
 			WithWorkflowIDPrefix("test-"), // Only our test workflows
 			WithStatus([]WorkflowStatusType{WorkflowStatusSuccess}))
 		if err != nil {
@@ -800,7 +800,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 5: Filter by status - ERROR
-		errorWorkflows, err := ListWorkflows(clientCtx,
+		errorWorkflows, err := clientCtx.ListWorkflows(
 			WithWorkflowIDPrefix("test-"),
 			WithStatus([]WorkflowStatusType{WorkflowStatusError}))
 		if err != nil {
@@ -818,7 +818,7 @@ func TestListWorkflows(t *testing.T) {
 
 		// Test 6: Filter by time range - first 5 workflows (start to start+500ms)
 		firstHalfTime := testStartTime.Add(500 * time.Millisecond)
-		firstHalfWorkflows, err := ListWorkflows(clientCtx,
+		firstHalfWorkflows, err := clientCtx.ListWorkflows(
 			WithWorkflowIDPrefix("test-"),
 			WithEndTime(firstHalfTime))
 		if err != nil {
@@ -829,7 +829,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 6b: Filter by time range - last 5 workflows (start+500ms to end)
-		secondHalfWorkflows, err := ListWorkflows(clientCtx,
+		secondHalfWorkflows, err := clientCtx.ListWorkflows(
 			WithWorkflowIDPrefix("test-"),
 			WithStartTime(firstHalfTime))
 		if err != nil {
@@ -840,7 +840,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 7: Test sorting order (ascending - default)
-		ascWorkflows, err := ListWorkflows(clientCtx,
+		ascWorkflows, err := clientCtx.ListWorkflows(
 			WithWorkflowIDPrefix("test-"),
 			WithSortDesc(false))
 		if err != nil {
@@ -848,7 +848,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 8: Test sorting order (descending)
-		descWorkflows, err := ListWorkflows(clientCtx,
+		descWorkflows, err := clientCtx.ListWorkflows(
 			WithWorkflowIDPrefix("test-"),
 			WithSortDesc(true))
 		if err != nil {
@@ -882,7 +882,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 9: Test limit and offset
-		limitedWorkflows, err := ListWorkflows(clientCtx,
+		limitedWorkflows, err := clientCtx.ListWorkflows(
 			WithWorkflowIDPrefix("test-"),
 			WithLimit(5))
 		if err != nil {
@@ -899,7 +899,7 @@ func TestListWorkflows(t *testing.T) {
 			}
 		}
 
-		offsetWorkflows, err := ListWorkflows(clientCtx,
+		offsetWorkflows, err := clientCtx.ListWorkflows(
 			WithWorkflowIDPrefix("test-"),
 			WithOffset(5),
 			WithLimit(3))
@@ -918,7 +918,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 10: Test input/output loading
-		noDataWorkflows, err := ListWorkflows(clientCtx,
+		noDataWorkflows, err := clientCtx.ListWorkflows(
 			WithWorkflowIDs(workflowIDs[:2]),
 			WithLoadInput(false),
 			WithLoadOutput(false))

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -269,7 +269,7 @@ func TestCancelResume(t *testing.T) {
 		}
 
 		// Cancel the workflow
-		err = clientCtx.CancelWorkflow(workflowID)
+		err = CancelWorkflow(clientCtx, workflowID)
 		if err != nil {
 			t.Fatalf("failed to cancel workflow: %v", err)
 		}
@@ -368,7 +368,7 @@ func TestCancelResume(t *testing.T) {
 		time.Sleep(500 * time.Millisecond)
 
 		// Cancel the workflow before timeout expires
-		err = clientCtx.CancelWorkflow(workflowID)
+		err = CancelWorkflow(clientCtx, workflowID)
 		if err != nil {
 			t.Fatalf("failed to cancel workflow: %v", err)
 		}
@@ -447,7 +447,7 @@ func TestCancelResume(t *testing.T) {
 		nonExistentWorkflowID := "non-existent-workflow-id"
 
 		// Try to cancel a non-existent workflow
-		err := clientCtx.CancelWorkflow(nonExistentWorkflowID)
+		err := CancelWorkflow(clientCtx, nonExistentWorkflowID)
 		if err == nil {
 			t.Fatal("expected error when canceling non-existent workflow, but got none")
 		}
@@ -848,7 +848,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 1: List all workflows (no filters)
-		allWorkflows, err := clientCtx.ListWorkflows()
+		allWorkflows, err := ListWorkflows(clientCtx)
 		if err != nil {
 			t.Fatalf("failed to list all workflows: %v", err)
 		}
@@ -858,7 +858,7 @@ func TestListWorkflows(t *testing.T) {
 
 		// Test 2: Filter by workflow IDs
 		expectedIDs := workflowIDs[:3]
-		specificWorkflows, err := clientCtx.ListWorkflows(WithWorkflowIDs(expectedIDs))
+		specificWorkflows, err := ListWorkflows(clientCtx, WithWorkflowIDs(expectedIDs))
 		if err != nil {
 			t.Fatalf("failed to list workflows by IDs: %v", err)
 		}
@@ -877,7 +877,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 3: Filter by workflow ID prefix
-		batchWorkflows, err := clientCtx.ListWorkflows(WithWorkflowIDPrefix("test-batch-"))
+		batchWorkflows, err := ListWorkflows(clientCtx, WithWorkflowIDPrefix("test-batch-"))
 		if err != nil {
 			t.Fatalf("failed to list workflows by prefix: %v", err)
 		}
@@ -892,7 +892,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 4: Filter by status - SUCCESS
-		successWorkflows, err := clientCtx.ListWorkflows(
+		successWorkflows, err := ListWorkflows(clientCtx,
 			WithWorkflowIDPrefix("test-"), // Only our test workflows
 			WithStatus([]WorkflowStatusType{WorkflowStatusSuccess}))
 		if err != nil {
@@ -909,7 +909,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 5: Filter by status - ERROR
-		errorWorkflows, err := clientCtx.ListWorkflows(
+		errorWorkflows, err := ListWorkflows(clientCtx,
 			WithWorkflowIDPrefix("test-"),
 			WithStatus([]WorkflowStatusType{WorkflowStatusError}))
 		if err != nil {
@@ -927,7 +927,7 @@ func TestListWorkflows(t *testing.T) {
 
 		// Test 6: Filter by time range - first 5 workflows (start to start+500ms)
 		firstHalfTime := testStartTime.Add(500 * time.Millisecond)
-		firstHalfWorkflows, err := clientCtx.ListWorkflows(
+		firstHalfWorkflows, err := ListWorkflows(clientCtx,
 			WithWorkflowIDPrefix("test-"),
 			WithEndTime(firstHalfTime))
 		if err != nil {
@@ -938,7 +938,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 6b: Filter by time range - last 5 workflows (start+500ms to end)
-		secondHalfWorkflows, err := clientCtx.ListWorkflows(
+		secondHalfWorkflows, err := ListWorkflows(clientCtx,
 			WithWorkflowIDPrefix("test-"),
 			WithStartTime(firstHalfTime))
 		if err != nil {
@@ -949,7 +949,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 7: Test sorting order (ascending - default)
-		ascWorkflows, err := clientCtx.ListWorkflows(
+		ascWorkflows, err := ListWorkflows(clientCtx,
 			WithWorkflowIDPrefix("test-"),
 			WithSortDesc(false))
 		if err != nil {
@@ -957,7 +957,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 8: Test sorting order (descending)
-		descWorkflows, err := clientCtx.ListWorkflows(
+		descWorkflows, err := ListWorkflows(clientCtx,
 			WithWorkflowIDPrefix("test-"),
 			WithSortDesc(true))
 		if err != nil {
@@ -991,7 +991,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 9: Test limit and offset
-		limitedWorkflows, err := clientCtx.ListWorkflows(
+		limitedWorkflows, err := ListWorkflows(clientCtx,
 			WithWorkflowIDPrefix("test-"),
 			WithLimit(5))
 		if err != nil {
@@ -1008,7 +1008,7 @@ func TestListWorkflows(t *testing.T) {
 			}
 		}
 
-		offsetWorkflows, err := clientCtx.ListWorkflows(
+		offsetWorkflows, err := ListWorkflows(clientCtx,
 			WithWorkflowIDPrefix("test-"),
 			WithOffset(5),
 			WithLimit(3))
@@ -1027,7 +1027,7 @@ func TestListWorkflows(t *testing.T) {
 		}
 
 		// Test 10: Test input/output loading
-		noDataWorkflows, err := clientCtx.ListWorkflows(
+		noDataWorkflows, err := ListWorkflows(clientCtx,
 			WithWorkflowIDs(workflowIDs[:2]),
 			WithLoadInput(false),
 			WithLoadOutput(false))

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -1,0 +1,174 @@
+package dbos
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// Simple workflow that will be executed on the server
+func serverWorkflow(ctx DBOSContext, input string) (string, error) {
+	if input != "test-input" {
+		return "", fmt.Errorf("unexpected input: %s", input)
+	}
+	return "processed: " + input, nil
+}
+
+func TestClientEnqueue(t *testing.T) {
+	// Setup server context - this will process tasks
+	serverCtx := setupDBOS(t, true, true)
+
+	// Create queue for communication between client and server
+	queue := NewWorkflowQueue(serverCtx, "client-enqueue-queue")
+
+	// Register workflows with custom names so client can reference them
+	RegisterWorkflow(serverCtx, serverWorkflow, WithWorkflowName("ServerWorkflow"))
+
+	// Workflow that blocks until cancelled (for timeout test)
+	blockingWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(10 * time.Second):
+			return "should-never-complete", nil
+		}
+	}
+	RegisterWorkflow(serverCtx, blockingWorkflow, WithWorkflowName("BlockingWorkflow"))
+
+	// Launch the server context to start processing tasks
+	err := serverCtx.Launch()
+	if err != nil {
+		t.Fatalf("failed to launch server DBOS instance: %v", err)
+	}
+
+	// Setup client context - this will enqueue tasks
+	clientCtx := setupDBOS(t, false, false) // Don't drop DB, don't check for leaks
+
+	t.Run("EnqueueAndGetResult", func(t *testing.T) {
+		// Client enqueues a task using the new Enqueue method
+		handle, err := Enqueue[string, string](clientCtx, GenericEnqueueOptions[string]{
+			WorkflowName:       "ServerWorkflow",
+			QueueName:          queue.Name,
+			WorkflowInput:      "test-input",
+			ApplicationVersion: serverCtx.GetApplicationVersion(),
+		})
+		if err != nil {
+			t.Fatalf("failed to enqueue workflow from client: %v", err)
+		}
+
+		// Verify we got a polling handle
+		_, ok := handle.(*workflowPollingHandle[string])
+		if !ok {
+			t.Fatalf("expected handle to be of type workflowPollingHandle, got %T", handle)
+		}
+
+		// Client retrieves the result
+		result, err := handle.GetResult()
+		if err != nil {
+			t.Fatalf("failed to get result from enqueued workflow: %v", err)
+		}
+
+		expectedResult := "processed: test-input"
+		if result != expectedResult {
+			t.Fatalf("expected result to be '%s', got '%s'", expectedResult, result)
+		}
+
+		// Verify the workflow status
+		status, err := handle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get workflow status: %v", err)
+		}
+
+		if status.Status != WorkflowStatusSuccess {
+			t.Fatalf("expected workflow status to be SUCCESS, got %v", status.Status)
+		}
+
+		if status.Name != "ServerWorkflow" {
+			t.Fatalf("expected workflow name to be 'ServerWorkflow', got '%s'", status.Name)
+		}
+
+		if status.QueueName != queue.Name {
+			t.Fatalf("expected queue name to be '%s', got '%s'", queue.Name, status.QueueName)
+		}
+
+		if !queueEntriesAreCleanedUp(serverCtx) {
+			t.Fatal("expected queue entries to be cleaned up after global concurrency test")
+		}
+	})
+
+	t.Run("EnqueueWithCustomWorkflowID", func(t *testing.T) {
+		customWorkflowID := "custom-client-workflow-id"
+
+		// Client enqueues a task with a custom workflow ID
+		_, err := Enqueue[string, string](clientCtx, GenericEnqueueOptions[string]{
+			WorkflowName:  "ServerWorkflow",
+			QueueName:     queue.Name,
+			WorkflowID:    customWorkflowID,
+			WorkflowInput: "test-input",
+		})
+		if err != nil {
+			t.Fatalf("failed to enqueue workflow with custom ID: %v", err)
+		}
+
+		// Verify the workflow ID is what we set
+		retrieveHandle, err := RetrieveWorkflow[string](clientCtx, customWorkflowID)
+		if err != nil {
+			t.Fatalf("failed to retrieve workflow by custom ID: %v", err)
+		}
+
+		result, err := retrieveHandle.GetResult()
+		if err != nil {
+			t.Fatalf("failed to get result from retrieved workflow: %v", err)
+		}
+
+		if result != "processed: test-input" {
+			t.Fatalf("expected retrieved workflow result to be 'processed: test-input', got '%s'", result)
+		}
+
+		if !queueEntriesAreCleanedUp(serverCtx) {
+			t.Fatal("expected queue entries to be cleaned up after global concurrency test")
+		}
+	})
+
+	t.Run("EnqueueWithTimeout", func(t *testing.T) {
+		handle, err := Enqueue[string, string](clientCtx, GenericEnqueueOptions[string]{
+			WorkflowName:    "BlockingWorkflow",
+			QueueName:       queue.Name,
+			WorkflowInput:   "blocking-input",
+			WorkflowTimeout: 500 * time.Millisecond,
+		})
+		if err != nil {
+			t.Fatalf("failed to enqueue blocking workflow: %v", err)
+		}
+
+		// Should timeout when trying to get result
+		_, err = handle.GetResult()
+		if err == nil {
+			t.Fatal("expected timeout error, but got none")
+		}
+
+		dbosErr, ok := err.(*DBOSError)
+		if !ok {
+			t.Fatalf("expected error to be of type *DBOSError, got %T", err)
+		}
+
+		if dbosErr.Code != AwaitedWorkflowCancelled {
+			t.Fatalf("expected error code to be AwaitedWorkflowCancelled, got %v", dbosErr.Code)
+		}
+
+		// Verify workflow is cancelled
+		status, err := handle.GetStatus()
+		if err != nil {
+			t.Fatalf("failed to get workflow status: %v", err)
+		}
+
+		if status.Status != WorkflowStatusCancelled {
+			t.Fatalf("expected workflow status to be CANCELLED, got %v", status.Status)
+		}
+	})
+
+	// Verify all queue entries are cleaned up
+	if !queueEntriesAreCleanedUp(serverCtx) {
+		t.Fatal("expected queue entries to be cleaned up after client tests")
+	}
+}

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -711,41 +711,6 @@ func TestForkWorkflow(t *testing.T) {
 		}
 	})
 
-	t.Run("ForkWithInvalidStep", func(t *testing.T) {
-		originalWorkflowID := "original-workflow-invalid-step"
-
-		// Create an original workflow first
-		handle, err := Enqueue[string, string](clientCtx, GenericEnqueueOptions[string]{
-			WorkflowName:       "ParentWorkflow",
-			QueueName:          queue.Name,
-			WorkflowID:         originalWorkflowID,
-			WorkflowInput:      "test",
-			ApplicationVersion: serverCtx.GetApplicationVersion(),
-		})
-		if err != nil {
-			t.Fatalf("failed to enqueue original workflow: %v", err)
-		}
-
-		// Wait for completion
-		_, err = handle.GetResult()
-		if err != nil {
-			t.Fatalf("failed to get result from original workflow: %v", err)
-		}
-
-		// Try to fork at step 999 (beyond workflow's actual steps)
-		_, err = clientCtx.ForkWorkflow(clientCtx, ForkWorkflowInput{
-			OriginalWorkflowID: originalWorkflowID,
-			StartStep:          999,
-		})
-		if err == nil {
-			t.Fatal("expected error when forking at step 999, but got none")
-		}
-		// Verify the error message
-		if !strings.Contains(err.Error(), "exceeds workflow's maximum step") {
-			t.Fatalf("expected error message to contain 'exceeds workflow's maximum step', got: %v", err)
-		}
-	})
-
 	// Verify all queue entries are cleaned up
 	if !queueEntriesAreCleanedUp(serverCtx) {
 		t.Fatal("expected queue entries to be cleaned up after fork workflow tests")

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -54,7 +54,7 @@ func processConfig(inputConfig *Config) (*Config, error) {
 
 	// Load defaults
 	if dbosConfig.Logger == nil {
-		dbosConfig.Logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		dbosConfig.Logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	}
 
 	return dbosConfig, nil

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -86,6 +86,8 @@ type DBOSContext interface {
 	// Workflow management
 	RetrieveWorkflow(_ DBOSContext, workflowID string) (WorkflowHandle[any], error) // Get a handle to an existing workflow
 	Enqueue(_ DBOSContext, params EnqueueOptions) (WorkflowHandle[any], error)      // Enqueue a new workflow with parameters
+	CancelWorkflow(workflowID string) error                                         // Cancel a workflow by setting its status to CANCELLED
+	ResumeWorkflow(_ DBOSContext, workflowID string) (WorkflowHandle[any], error)   // Resume a cancelled workflow
 
 	// Accessors
 	GetApplicationVersion() string // Get the application version for this context

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -88,7 +88,7 @@ type DBOSContext interface {
 	Enqueue(_ DBOSContext, params EnqueueOptions) (WorkflowHandle[any], error)                                      // Enqueue a new workflow with parameters
 	CancelWorkflow(workflowID string) error                                                                         // Cancel a workflow by setting its status to CANCELLED
 	ResumeWorkflow(_ DBOSContext, workflowID string) (WorkflowHandle[any], error)                                   // Resume a cancelled workflow
-	ForkWorkflow(_ DBOSContext, originalWorkflowID string, opts ...ForkWorkflowOption) (WorkflowHandle[any], error) // Fork a workflow from a specific step
+	ForkWorkflow(_ DBOSContext, input ForkWorkflowInput) (WorkflowHandle[any], error) // Fork a workflow from a specific step
 
 	// Accessors
 	GetApplicationVersion() string // Get the application version for this context

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -84,10 +84,11 @@ type DBOSContext interface {
 	GetWorkflowID() (string, error)                                                                               // Get the current workflow ID (only available within workflows)
 
 	// Workflow management
-	RetrieveWorkflow(_ DBOSContext, workflowID string) (WorkflowHandle[any], error) // Get a handle to an existing workflow
-	Enqueue(_ DBOSContext, params EnqueueOptions) (WorkflowHandle[any], error)      // Enqueue a new workflow with parameters
-	CancelWorkflow(workflowID string) error                                         // Cancel a workflow by setting its status to CANCELLED
-	ResumeWorkflow(_ DBOSContext, workflowID string) (WorkflowHandle[any], error)   // Resume a cancelled workflow
+	RetrieveWorkflow(_ DBOSContext, workflowID string) (WorkflowHandle[any], error)                                 // Get a handle to an existing workflow
+	Enqueue(_ DBOSContext, params EnqueueOptions) (WorkflowHandle[any], error)                                      // Enqueue a new workflow with parameters
+	CancelWorkflow(workflowID string) error                                                                         // Cancel a workflow by setting its status to CANCELLED
+	ResumeWorkflow(_ DBOSContext, workflowID string) (WorkflowHandle[any], error)                                   // Resume a cancelled workflow
+	ForkWorkflow(_ DBOSContext, originalWorkflowID string, opts ...ForkWorkflowOption) (WorkflowHandle[any], error) // Fork a workflow from a specific step
 
 	// Accessors
 	GetApplicationVersion() string // Get the application version for this context

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -76,7 +76,7 @@ type DBOSContext interface {
 	// Workflow operations
 	RunAsStep(_ DBOSContext, fn StepFunc) (any, error)                                                            // Execute a function as a durable step within a workflow
 	RunAsWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opts ...WorkflowOption) (WorkflowHandle[any], error) // Start a new workflow execution
-	Send(_ DBOSContext, input WorkflowSendInputInternal) error                                                    // Send a message to another workflow
+	Send(_ DBOSContext, input WorkflowSendInput) error                                                            // Send a message to another workflow
 	Recv(_ DBOSContext, input WorkflowRecvInput) (any, error)                                                     // Receive a message sent to this workflow
 	SetEvent(_ DBOSContext, input WorkflowSetEventInput) error                                                    // Set a key-value event for this workflow
 	GetEvent(_ DBOSContext, input WorkflowGetEventInput) (any, error)                                             // Get a key-value event from a target workflow
@@ -85,6 +85,7 @@ type DBOSContext interface {
 
 	// Workflow management
 	RetrieveWorkflow(_ DBOSContext, workflowID string) (WorkflowHandle[any], error) // Get a handle to an existing workflow
+	Enqueue(_ DBOSContext, params EnqueueOptions) (WorkflowHandle[any], error)      // Enqueue a new workflow with parameters
 
 	// Accessors
 	GetApplicationVersion() string // Get the application version for this context
@@ -114,8 +115,9 @@ type dbosContext struct {
 	workflowsWg *sync.WaitGroup
 
 	// Workflow registry
-	workflowRegistry map[string]workflowRegistryEntry
-	workflowRegMutex *sync.RWMutex
+	workflowRegistry        map[string]workflowRegistryEntry
+	workflowRegMutex        *sync.RWMutex
+	workflowCustomNametoFQN sync.Map // Maps fully qualified workflow names to custom names. Usefor when client enqueues a workflow by name because registry is indexed by FQN.
 
 	// Workflow scheduler
 	workflowScheduler *cron.Cron

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -82,6 +82,7 @@ type DBOSContext interface {
 	GetEvent(_ DBOSContext, input WorkflowGetEventInput) (any, error)                                             // Get a key-value event from a target workflow
 	Sleep(duration time.Duration) (time.Duration, error)                                                          // Durable sleep that survives workflow recovery
 	GetWorkflowID() (string, error)                                                                               // Get the current workflow ID (only available within workflows)
+	GetStepID() (int, error)                                                                                      // Get the current step ID (only available within workflows)
 
 	// Workflow management
 	RetrieveWorkflow(_ DBOSContext, workflowID string) (WorkflowHandle[any], error)   // Get a handle to an existing workflow

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -84,11 +84,12 @@ type DBOSContext interface {
 	GetWorkflowID() (string, error)                                                                               // Get the current workflow ID (only available within workflows)
 
 	// Workflow management
-	RetrieveWorkflow(_ DBOSContext, workflowID string) (WorkflowHandle[any], error)                                 // Get a handle to an existing workflow
-	Enqueue(_ DBOSContext, params EnqueueOptions) (WorkflowHandle[any], error)                                      // Enqueue a new workflow with parameters
-	CancelWorkflow(workflowID string) error                                                                         // Cancel a workflow by setting its status to CANCELLED
-	ResumeWorkflow(_ DBOSContext, workflowID string) (WorkflowHandle[any], error)                                   // Resume a cancelled workflow
+	RetrieveWorkflow(_ DBOSContext, workflowID string) (WorkflowHandle[any], error)   // Get a handle to an existing workflow
+	Enqueue(_ DBOSContext, params EnqueueOptions) (WorkflowHandle[any], error)        // Enqueue a new workflow with parameters
+	CancelWorkflow(workflowID string) error                                           // Cancel a workflow by setting its status to CANCELLED
+	ResumeWorkflow(_ DBOSContext, workflowID string) (WorkflowHandle[any], error)     // Resume a cancelled workflow
 	ForkWorkflow(_ DBOSContext, input ForkWorkflowInput) (WorkflowHandle[any], error) // Fork a workflow from a specific step
+	ListWorkflows(opts ...ListWorkflowsOption) ([]WorkflowStatus, error)              // List workflows based on filtering criteria
 
 	// Accessors
 	GetApplicationVersion() string // Get the application version for this context

--- a/dbos/queue.go
+++ b/dbos/queue.go
@@ -199,10 +199,16 @@ func (qr *queueRunner) run(ctx *dbosContext) {
 			}
 			for _, workflow := range dequeuedWorkflows {
 				// Find the workflow in the registry
-				registeredWorkflow, exists := ctx.workflowRegistry[workflow.name]
+
+				wfName, ok := ctx.workflowCustomNametoFQN.Load(workflow.name)
+				if !ok {
+					ctx.logger.Error("Workflow not found in registry", "workflow_name", workflow.name)
+					continue
+				}
+
+				registeredWorkflow, exists := ctx.workflowRegistry[wfName.(string)]
 				if !exists {
 					ctx.logger.Error("workflow function not found in registry", "workflow_name", workflow.name)
-					continue
 				}
 
 				// Deserialize input

--- a/dbos/queue.go
+++ b/dbos/queue.go
@@ -209,6 +209,7 @@ func (qr *queueRunner) run(ctx *dbosContext) {
 				registeredWorkflow, exists := ctx.workflowRegistry[wfName.(string)]
 				if !exists {
 					ctx.logger.Error("workflow function not found in registry", "workflow_name", workflow.name)
+					continue
 				}
 
 				// Deserialize input

--- a/dbos/recovery.go
+++ b/dbos/recovery.go
@@ -36,7 +36,13 @@ func recoverPendingWorkflows(ctx *dbosContext, executorIDs []string) ([]Workflow
 			continue
 		}
 
-		registeredWorkflow, exists := ctx.workflowRegistry[workflow.Name]
+		wfName, ok := ctx.workflowCustomNametoFQN.Load(workflow.Name)
+		if !ok {
+			ctx.logger.Error("Workflow not found in registry", "workflow_name", workflow.Name)
+			continue
+		}
+
+		registeredWorkflow, exists := ctx.workflowRegistry[wfName.(string)]
 		if !exists {
 			ctx.logger.Error("Workflow function not found in registry", "workflow_id", workflow.ID, "name", workflow.Name)
 			continue

--- a/dbos/recovery.go
+++ b/dbos/recovery.go
@@ -11,6 +11,7 @@ func recoverPendingWorkflows(ctx *dbosContext, executorIDs []string) ([]Workflow
 		status:             []WorkflowStatusType{WorkflowStatusPending},
 		executorIDs:        executorIDs,
 		applicationVersion: ctx.applicationVersion,
+		loadInput:          true,
 	})
 	if err != nil {
 		return nil, err

--- a/dbos/serialization_test.go
+++ b/dbos/serialization_test.go
@@ -103,9 +103,9 @@ func TestWorkflowEncoding(t *testing.T) {
 		}
 
 		// Test results from ListWorkflows
-		workflows, err := executor.(*dbosContext).systemDB.listWorkflows(context.Background(), listWorkflowsDBInput{
-			workflowIDs: []string{directHandle.GetWorkflowID()},
-		})
+		workflows, err := executor.ListWorkflows(WithWorkflowIDs(
+			[]string{directHandle.GetWorkflowID()},
+		))
 		if err != nil {
 			t.Fatalf("failed to list workflows: %v", err)
 		}
@@ -220,9 +220,9 @@ func TestWorkflowEncoding(t *testing.T) {
 		}
 
 		// Test results from ListWorkflows
-		workflows, err := executor.(*dbosContext).systemDB.listWorkflows(context.Background(), listWorkflowsDBInput{
-			workflowIDs: []string{directHandle.GetWorkflowID()},
-		})
+		workflows, err := executor.ListWorkflows(WithWorkflowIDs(
+			[]string{directHandle.GetWorkflowID()},
+		))
 		if err != nil {
 			t.Fatalf("failed to list workflows: %v", err)
 		}

--- a/dbos/serialization_test.go
+++ b/dbos/serialization_test.go
@@ -103,7 +103,7 @@ func TestWorkflowEncoding(t *testing.T) {
 		}
 
 		// Test results from ListWorkflows
-		workflows, err := executor.ListWorkflows(WithWorkflowIDs(
+		workflows, err := ListWorkflows(executor, WithWorkflowIDs(
 			[]string{directHandle.GetWorkflowID()},
 		))
 		if err != nil {
@@ -220,7 +220,7 @@ func TestWorkflowEncoding(t *testing.T) {
 		}
 
 		// Test results from ListWorkflows
-		workflows, err := executor.ListWorkflows(WithWorkflowIDs(
+		workflows, err := ListWorkflows(executor, WithWorkflowIDs(
 			[]string{directHandle.GetWorkflowID()},
 		))
 		if err != nil {

--- a/dbos/serialization_test.go
+++ b/dbos/serialization_test.go
@@ -317,7 +317,7 @@ func setEventUserDefinedTypeWorkflow(ctx DBOSContext, input string) (string, err
 		},
 	}
 
-	err := SetEvent(ctx, WorkflowSetEventInputGeneric[UserDefinedEventData]{Key: input, Message: eventData})
+	err := SetEvent(ctx, GenericWorkflowSetEventInput[UserDefinedEventData]{Key: input, Message: eventData})
 	if err != nil {
 		return "", err
 	}
@@ -394,7 +394,7 @@ func sendUserDefinedTypeWorkflow(ctx DBOSContext, destinationID string) (string,
 
 	// Send should automatically register this type with gob
 	// Note the explicit type parameter since compiler cannot infer UserDefinedEventData from string input
-	err := Send(ctx, WorkflowSendInput[UserDefinedEventData]{
+	err := Send(ctx, GenericWorkflowSendInput[UserDefinedEventData]{
 		DestinationID: destinationID,
 		Topic:         "user-defined-topic",
 		Message:       sendData,

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -580,12 +580,10 @@ func (s *sysDB) listWorkflows(ctx context.Context, input listWorkflowsDBInput) (
 			wf.QueueName = *queueName
 		}
 
-		// Handle NULL executorID
 		if executorID != nil && len(*executorID) > 0 {
 			wf.ExecutorID = *executorID
 		}
 
-		// We work with strings -- the DB could return NULL values
 		if applicationVersion != nil && len(*applicationVersion) > 0 {
 			wf.ApplicationVersion = *applicationVersion
 		}

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -829,17 +829,6 @@ func (s *sysDB) forkWorkflow(ctx context.Context, input forkWorkflowDBInput) err
 
 	originalWorkflow := wfs[0]
 
-	// Validate that startStep doesn't exceed the workflow's actual steps
-	maxStepQuery := `SELECT COALESCE(MAX(function_id), 0) FROM dbos.operation_outputs WHERE workflow_uuid = $1`
-	var maxStepID int
-	err = tx.QueryRow(ctx, maxStepQuery, input.originalWorkflowID).Scan(&maxStepID)
-	if err != nil {
-		return fmt.Errorf("failed to query max step ID: %w", err)
-	}
-	if input.startStep > maxStepID && maxStepID > 0 {
-		return fmt.Errorf("startStep %d exceeds workflow's maximum step %d", input.startStep, maxStepID)
-	}
-
 	// Determine the application version to use
 	appVersion := originalWorkflow.ApplicationVersion
 	if input.applicationVersion != "" {

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -821,11 +821,6 @@ func (s *sysDB) forkWorkflow(ctx context.Context, input forkWorkflowDBInput) err
 
 	originalWorkflow := wfs[0]
 
-	// Check if the workflow has completed successfully (required for forking)
-	if originalWorkflow.Status != WorkflowStatusSuccess {
-		return fmt.Errorf("cannot fork workflow %s: workflow must be in SUCCESS state, current state: %s", input.originalWorkflowID, originalWorkflow.Status)
-	}
-
 	// Validate that startStep doesn't exceed the workflow's actual steps
 	maxStepQuery := `SELECT COALESCE(MAX(function_id), 0) FROM dbos.operation_outputs WHERE workflow_uuid = $1`
 	var maxStepID int

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -809,7 +809,6 @@ func (s *sysDB) forkWorkflow(ctx context.Context, input forkWorkflowDBInput) err
 	listInput := listWorkflowsDBInput{
 		workflowIDs: []string{input.originalWorkflowID},
 		loadInput:   true,
-		loadOutput:  true,
 		tx:          tx,
 	}
 	wfs, err := s.listWorkflows(ctx, listInput)

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1238,6 +1238,11 @@ func RetrieveWorkflow[R any](ctx DBOSContext, workflowID string) (workflowPollin
 	if ctx == nil {
 		return workflowPollingHandle[R]{}, errors.New("dbosCtx cannot be nil")
 	}
+
+	// Register the output for gob encoding
+	var r R
+	gob.Register(r)
+
 	workflowStatus, err := ctx.(*dbosContext).systemDB.listWorkflows(ctx, listWorkflowsDBInput{
 		workflowIDs: []string{workflowID},
 	})
@@ -1395,6 +1400,11 @@ func ResumeWorkflow[R any](ctx DBOSContext, workflowID string) (WorkflowHandle[R
 	if ctx == nil {
 		return nil, errors.New("ctx cannot be nil")
 	}
+
+	// Register the output for gob encoding
+	var r R
+	gob.Register(r)
+
 	_, err := ctx.ResumeWorkflow(ctx, workflowID)
 	if err != nil {
 		return nil, err
@@ -1525,6 +1535,10 @@ func ForkWorkflow[R any](ctx DBOSContext, originalWorkflowID string, opts ...For
 	if ctx == nil {
 		return nil, errors.New("ctx cannot be nil")
 	}
+
+	// Register the output for gob encoding
+	var r R
+	gob.Register(r)
 
 	handle, err := ctx.ForkWorkflow(ctx, originalWorkflowID, opts...)
 	if err != nil {

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1418,126 +1418,85 @@ func ResumeWorkflow[R any](ctx DBOSContext, workflowID string) (WorkflowHandle[R
 	return &workflowPollingHandle[R]{workflowID: workflowID, dbosContext: ctx}, nil
 }
 
-// forkWorkflowParams holds configuration parameters for forking workflows
-type forkWorkflowParams struct {
-	applicationVersion string
-	forkedWorkflowID   string
-	startStep          uint
+// ForkWorkflowInput holds configuration parameters for forking workflows.
+// It replaces the functional options pattern to comply with CS-5 style guidelines.
+type ForkWorkflowInput struct {
+	OriginalWorkflowID string // Required: The UUID of the original workflow to fork from
+	ForkedWorkflowID   string // Optional: Custom workflow ID for the forked workflow (auto-generated if empty)
+	StartStep          uint   // Optional: Step to start the forked workflow from (default: 0)
+	ApplicationVersion string // Optional: Application version for the forked workflow (inherits from original if empty)
 }
 
-// ForkWorkflowOption is a functional option for configuring fork workflow execution parameters.
-type ForkWorkflowOption func(*forkWorkflowParams)
-
-// WithForkApplicationVersion overrides the application version for the forked workflow.
-// If not specified, the original workflow's application version is used.
-//
-// Example:
-//
-//	dbos.ForkWorkflow[Result](ctx, originalID, 1,
-//	    dbos.WithForkApplicationVersion("v2.0.0"))
-func WithForkApplicationVersion(version string) ForkWorkflowOption {
-	return func(p *forkWorkflowParams) {
-		p.applicationVersion = version
-	}
-}
-
-// WithForkStartStep overrides the start step for the forked workflow.
-// This is an alternative to specifying the startStep as a parameter.
-// If both are specified, this option takes precedence.
-//
-// Example:
-//
-//	dbos.ForkWorkflow[Result](ctx, originalID, 1,
-//	    dbos.WithForkStartStep(5)) // Will start from step 5, not step 1
-func WithForkStartStep(startStep uint) ForkWorkflowOption {
-	return func(p *forkWorkflowParams) {
-		p.startStep = startStep
-	}
-}
-
-// WithForkWorkflowID sets a custom workflow ID for the forked workflow.
-// If not specified, a new UUID will be generated automatically.
-// The workflow ID must be unique across all workflows.
-//
-// Example:
-//
-//	dbos.ForkWorkflow[Result](ctx, originalID, 1,
-//	    dbos.WithForkWorkflowID("my-custom-fork-id"))
-func WithForkWorkflowID(workflowID string) ForkWorkflowOption {
-	return func(p *forkWorkflowParams) {
-		p.forkedWorkflowID = workflowID
-	}
-}
-
-func (c *dbosContext) ForkWorkflow(_ DBOSContext, originalWorkflowID string, opts ...ForkWorkflowOption) (WorkflowHandle[any], error) {
-	// Parse options
-	params := &forkWorkflowParams{}
-	for _, opt := range opts {
-		opt(params)
-	}
-
-	if originalWorkflowID == "" {
+func (c *dbosContext) ForkWorkflow(_ DBOSContext, input ForkWorkflowInput) (WorkflowHandle[any], error) {
+	if input.OriginalWorkflowID == "" {
 		return nil, errors.New("original workflow ID cannot be empty")
 	}
 
-	// Generate new workflow ID
-	if params.forkedWorkflowID == "" {
-		params.forkedWorkflowID = uuid.New().String()
+	// Generate new workflow ID if not provided
+	forkedWorkflowID := input.ForkedWorkflowID
+	if forkedWorkflowID == "" {
+		forkedWorkflowID = uuid.New().String()
 	}
 
 	// Create input for system database
-	input := forkWorkflowDBInput{
-		originalWorkflowID: originalWorkflowID,
-		forkedWorkflowID:   params.forkedWorkflowID,
-		startStep:          int(params.startStep),
-		applicationVersion: params.applicationVersion,
+	dbInput := forkWorkflowDBInput{
+		originalWorkflowID: input.OriginalWorkflowID,
+		forkedWorkflowID:   forkedWorkflowID,
+		startStep:          int(input.StartStep),
+		applicationVersion: input.ApplicationVersion,
 	}
 
 	// Call system database method
-	err := c.systemDB.forkWorkflow(c, input)
+	err := c.systemDB.forkWorkflow(c, dbInput)
 	if err != nil {
 		return nil, err
 	}
 
 	return &workflowPollingHandle[any]{
-		workflowID:  params.forkedWorkflowID,
+		workflowID:  forkedWorkflowID,
 		dbosContext: c,
 	}, nil
 }
 
 // ForkWorkflow creates a new workflow instance by copying an existing workflow from a specific step.
-// The forked workflow will have a new UUID and will execute from the specified startStep.
-// If startStep > 1, the forked workflow will have the operation outputs from steps 1 to startStep-1
+// The forked workflow will have a new UUID and will execute from the specified StartStep.
+// If StartStep > 0, the forked workflow will have the operation outputs from steps 0 to StartStep-1
 // copied from the original workflow.
 //
 // Parameters:
 //   - ctx: DBOS context for the operation
-//   - originalWorkflowID: The UUID of the original workflow to fork from
-//   - opts: Optional configuration parameters for the forked workflow using functional options
+//   - input: Configuration parameters for the forked workflow
 //
-// Available functional options:
-//   - WithForkWorkflowID: Set a custom workflow ID for the forked workflow
-//   - WithForkStartStep: Override the start step (alternative to the startStep parameter)
-//   - WithForkApplicationVersion: Set a specific application version for the forked workflow
+// The input struct contains:
+//   - OriginalWorkflowID: The UUID of the original workflow to fork from (required)
+//   - ForkedWorkflowID: Custom workflow ID for the forked workflow (optional, auto-generated if empty)
+//   - StartStep: Step to start the forked workflow from (optional, default: 0)
+//   - ApplicationVersion: Application version for the forked workflow (optional, inherits from original if empty)
 //
 // Returns a typed workflow handle for the newly created forked workflow.
 //
 // Example usage:
 //
 //	// Basic fork from step 5
-//	handle, err := dbos.ForkWorkflow[MyResultType](ctx, "original-workflow-id", 5)
+//	handle, err := dbos.ForkWorkflow[MyResultType](ctx, dbos.ForkWorkflowInput{
+//	    OriginalWorkflowID: "original-workflow-id",
+//	    StartStep:          5,
+//	})
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
 //
 //	// Fork with custom workflow ID and application version
-//	handle, err := dbos.ForkWorkflow[MyResultType](ctx, "original-workflow-id", 3,
-//	    dbos.WithForkWorkflowID("my-custom-fork-id"),
-//	    dbos.WithForkApplicationVersion("v2.0.0"))
+//	handle, err := dbos.ForkWorkflow[MyResultType](ctx, dbos.ForkWorkflowInput{
+//	    OriginalWorkflowID: "original-workflow-id",
+//	    ForkedWorkflowID:   "my-custom-fork-id",
+//	    StartStep:          3,
+//	    ApplicationVersion: "v2.0.0",
+//	})
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
-func ForkWorkflow[R any](ctx DBOSContext, originalWorkflowID string, opts ...ForkWorkflowOption) (WorkflowHandle[R], error) {
+func ForkWorkflow[R any](ctx DBOSContext, input ForkWorkflowInput) (WorkflowHandle[R], error) {
 	if ctx == nil {
 		return nil, errors.New("ctx cannot be nil")
 	}
@@ -1546,7 +1505,7 @@ func ForkWorkflow[R any](ctx DBOSContext, originalWorkflowID string, opts ...For
 	var r R
 	gob.Register(r)
 
-	handle, err := ctx.ForkWorkflow(ctx, originalWorkflowID, opts...)
+	handle, err := ctx.ForkWorkflow(ctx, input)
 	if err != nil {
 		return nil, err
 	}

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -379,6 +379,7 @@ func RegisterWorkflow[P any, R any](ctx DBOSContext, fn GenericWorkflowFunc[P, R
 		// This type check is redundant with the one in the wrapper, but I'd better be safe than sorry
 		typedInput, ok := input.(P)
 		if !ok {
+			// FIXME: we need to record the error in the database here
 			return nil, newWorkflowUnexpectedInputType(fqn, fmt.Sprintf("%T", typedInput), fmt.Sprintf("%T", input))
 		}
 		return fn(ctx, typedInput)
@@ -387,6 +388,7 @@ func RegisterWorkflow[P any, R any](ctx DBOSContext, fn GenericWorkflowFunc[P, R
 	typeErasedWrapper := WrappedWorkflowFunc(func(ctx DBOSContext, input any, opts ...WorkflowOption) (WorkflowHandle[any], error) {
 		typedInput, ok := input.(P)
 		if !ok {
+			// FIXME: we need to record the error in the database here
 			return nil, newWorkflowUnexpectedInputType(fqn, fmt.Sprintf("%T", typedInput), fmt.Sprintf("%T", input))
 		}
 

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -23,12 +23,12 @@ import (
 type WorkflowStatusType string
 
 const (
-	WorkflowStatusPending         WorkflowStatusType = "PENDING"          // Workflow is running or ready to run
-	WorkflowStatusEnqueued        WorkflowStatusType = "ENQUEUED"         // Workflow is queued and waiting for execution
-	WorkflowStatusSuccess         WorkflowStatusType = "SUCCESS"          // Workflow completed successfully
-	WorkflowStatusError           WorkflowStatusType = "ERROR"            // Workflow completed with an error
-	WorkflowStatusCancelled       WorkflowStatusType = "CANCELLED"        // Workflow was cancelled (manually or due to timeout)
-	WorkflowStatusRetriesExceeded WorkflowStatusType = "RETRIES_EXCEEDED" // Workflow exceeded maximum retry attempts
+	WorkflowStatusPending         WorkflowStatusType = "PENDING"                        // Workflow is running or ready to run
+	WorkflowStatusEnqueued        WorkflowStatusType = "ENQUEUED"                       // Workflow is queued and waiting for execution
+	WorkflowStatusSuccess         WorkflowStatusType = "SUCCESS"                        // Workflow completed successfully
+	WorkflowStatusError           WorkflowStatusType = "ERROR"                          // Workflow completed with an error
+	WorkflowStatusCancelled       WorkflowStatusType = "CANCELLED"                      // Workflow was cancelled (manually or due to timeout)
+	WorkflowStatusRetriesExceeded WorkflowStatusType = "MAX_RECOVERY_ATTEMPTS_EXCEEDED" // Workflow exceeded maximum retry attempts
 )
 
 // WorkflowStatus contains comprehensive information about a workflow's current state and execution history.

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1346,7 +1346,7 @@ type sendWorkflowInput struct {
 }
 
 func sendWorkflow(ctx DBOSContext, input sendWorkflowInput) (string, error) {
-	err := Send(ctx, WorkflowSendInput[string]{
+	err := Send(ctx, GenericWorkflowSendInput[string]{
 		DestinationID: input.DestinationID,
 		Topic:         input.Topic,
 		Message:       "message1",
@@ -1354,11 +1354,11 @@ func sendWorkflow(ctx DBOSContext, input sendWorkflowInput) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	err = Send(ctx, WorkflowSendInput[string]{DestinationID: input.DestinationID, Topic: input.Topic, Message: "message2"})
+	err = Send(ctx, GenericWorkflowSendInput[string]{DestinationID: input.DestinationID, Topic: input.Topic, Message: "message2"})
 	if err != nil {
 		return "", err
 	}
-	err = Send(ctx, WorkflowSendInput[string]{DestinationID: input.DestinationID, Topic: input.Topic, Message: "message3"})
+	err = Send(ctx, GenericWorkflowSendInput[string]{DestinationID: input.DestinationID, Topic: input.Topic, Message: "message3"})
 	if err != nil {
 		return "", err
 	}
@@ -1402,7 +1402,7 @@ func receiveWorkflowCoordinated(ctx DBOSContext, input struct {
 
 func sendStructWorkflow(ctx DBOSContext, input sendWorkflowInput) (string, error) {
 	testStruct := sendRecvType{Value: "test-struct-value"}
-	err := Send(ctx, WorkflowSendInput[sendRecvType]{DestinationID: input.DestinationID, Topic: input.Topic, Message: testStruct})
+	err := Send(ctx, GenericWorkflowSendInput[sendRecvType]{DestinationID: input.DestinationID, Topic: input.Topic, Message: testStruct})
 	return "", err
 }
 
@@ -1411,7 +1411,7 @@ func receiveStructWorkflow(ctx DBOSContext, topic string) (sendRecvType, error) 
 }
 
 func sendIdempotencyWorkflow(ctx DBOSContext, input sendWorkflowInput) (string, error) {
-	err := Send(ctx, WorkflowSendInput[string]{DestinationID: input.DestinationID, Topic: input.Topic, Message: "m1"})
+	err := Send(ctx, GenericWorkflowSendInput[string]{DestinationID: input.DestinationID, Topic: input.Topic, Message: "m1"})
 	if err != nil {
 		return "", err
 	}
@@ -1432,7 +1432,7 @@ func receiveIdempotencyWorkflow(ctx DBOSContext, topic string) (string, error) {
 }
 
 func stepThatCallsSend(ctx context.Context, input sendWorkflowInput) (string, error) {
-	err := Send(ctx.(DBOSContext), WorkflowSendInput[string]{
+	err := Send(ctx.(DBOSContext), GenericWorkflowSendInput[string]{
 		DestinationID: input.DestinationID,
 		Topic:         input.Topic,
 		Message:       "message-from-step",
@@ -1678,7 +1678,7 @@ func TestSendRecv(t *testing.T) {
 
 		// Send messages from outside a workflow context (should work now)
 		for i := range 3 {
-			err = Send(dbosCtx, WorkflowSendInput[string]{
+			err = Send(dbosCtx, GenericWorkflowSendInput[string]{
 				DestinationID: receiveHandle.GetWorkflowID(),
 				Topic:         "outside-workflow-topic",
 				Message:       fmt.Sprintf("message%d", i+1),
@@ -1935,7 +1935,7 @@ type setEventWorkflowInput struct {
 }
 
 func setEventWorkflow(ctx DBOSContext, input setEventWorkflowInput) (string, error) {
-	err := SetEvent(ctx, WorkflowSetEventInputGeneric[string]{Key: input.Key, Message: input.Message})
+	err := SetEvent(ctx, GenericWorkflowSetEventInput[string]{Key: input.Key, Message: input.Message})
 	if err != nil {
 		return "", err
 	}
@@ -1956,7 +1956,7 @@ func getEventWorkflow(ctx DBOSContext, input setEventWorkflowInput) (string, err
 
 func setTwoEventsWorkflow(ctx DBOSContext, input setEventWorkflowInput) (string, error) {
 	// Set the first event
-	err := SetEvent(ctx, WorkflowSetEventInputGeneric[string]{Key: "event1", Message: "first-event-message"})
+	err := SetEvent(ctx, GenericWorkflowSetEventInput[string]{Key: "event1", Message: "first-event-message"})
 	if err != nil {
 		return "", err
 	}
@@ -1965,7 +1965,7 @@ func setTwoEventsWorkflow(ctx DBOSContext, input setEventWorkflowInput) (string,
 	setSecondEventSignal.Wait()
 
 	// Set the second event
-	err = SetEvent(ctx, WorkflowSetEventInputGeneric[string]{Key: "event2", Message: "second-event-message"})
+	err = SetEvent(ctx, GenericWorkflowSetEventInput[string]{Key: "event2", Message: "second-event-message"})
 	if err != nil {
 		return "", err
 	}
@@ -1974,7 +1974,7 @@ func setTwoEventsWorkflow(ctx DBOSContext, input setEventWorkflowInput) (string,
 }
 
 func setEventIdempotencyWorkflow(ctx DBOSContext, input setEventWorkflowInput) (string, error) {
-	err := SetEvent(ctx, WorkflowSetEventInputGeneric[string]{Key: input.Key, Message: input.Message})
+	err := SetEvent(ctx, GenericWorkflowSetEventInput[string]{Key: input.Key, Message: input.Message})
 	if err != nil {
 		return "", err
 	}
@@ -2342,7 +2342,7 @@ func TestSetGetEvent(t *testing.T) {
 
 	t.Run("SetGetEventMustRunInsideWorkflows", func(t *testing.T) {
 		// Attempt to run SetEvent outside of a workflow context
-		err := SetEvent(dbosCtx, WorkflowSetEventInputGeneric[string]{Key: "test-key", Message: "test-message"})
+		err := SetEvent(dbosCtx, GenericWorkflowSetEventInput[string]{Key: "test-key", Message: "test-message"})
 		if err == nil {
 			t.Fatal("expected error when running SetEvent outside of workflow context, but got none")
 		}
@@ -3018,7 +3018,7 @@ func notificationWaiterWorkflow(ctx DBOSContext, pairID int) (string, error) {
 }
 
 func notificationSetterWorkflow(ctx DBOSContext, pairID int) (string, error) {
-	err := SetEvent(ctx, WorkflowSetEventInputGeneric[string]{
+	err := SetEvent(ctx, GenericWorkflowSetEventInput[string]{
 		Key:     "event-key",
 		Message: fmt.Sprintf("notification-message-%d", pairID),
 	})
@@ -3040,7 +3040,7 @@ func sendRecvReceiverWorkflow(ctx DBOSContext, pairID int) (string, error) {
 }
 
 func sendRecvSenderWorkflow(ctx DBOSContext, pairID int) (string, error) {
-	err := Send(ctx, WorkflowSendInput[string]{
+	err := Send(ctx, GenericWorkflowSendInput[string]{
 		DestinationID: fmt.Sprintf("send-recv-receiver-%d", pairID),
 		Topic:         "send-recv-topic",
 		Message:       fmt.Sprintf("send-recv-message-%d", pairID),

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -541,7 +541,7 @@ func TestChildWorkflow(t *testing.T) {
 
 	// Create child workflows with executor
 	childWf := func(dbosCtx DBOSContext, input Inheritance) (string, error) {
-		workflowID, err := dbosCtx.GetWorkflowID()
+		workflowID, err := GetWorkflowID(dbosCtx)
 		if err != nil {
 			return "", fmt.Errorf("failed to get workflow ID: %w", err)
 		}
@@ -557,7 +557,7 @@ func TestChildWorkflow(t *testing.T) {
 	RegisterWorkflow(dbosCtx, childWf)
 
 	parentWf := func(ctx DBOSContext, input Inheritance) (string, error) {
-		workflowID, err := ctx.GetWorkflowID()
+		workflowID, err := GetWorkflowID(ctx)
 		if err != nil {
 			return "", fmt.Errorf("failed to get workflow ID: %w", err)
 		}
@@ -624,7 +624,7 @@ func TestChildWorkflow(t *testing.T) {
 	RegisterWorkflow(dbosCtx, parentWf)
 
 	grandParentWf := func(ctx DBOSContext, r int) (string, error) {
-		workflowID, err := ctx.GetWorkflowID()
+		workflowID, err := GetWorkflowID(ctx)
 		if err != nil {
 			return "", fmt.Errorf("failed to get workflow ID: %w", err)
 		}
@@ -1064,7 +1064,7 @@ var (
 
 func deadLetterQueueWorkflow(ctx DBOSContext, input string) (int, error) {
 	recoveryCount++
-	wfid, err := ctx.GetWorkflowID()
+	wfid, err := GetWorkflowID(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get workflow ID: %v", err)
 	}
@@ -2528,7 +2528,7 @@ var (
 )
 
 func sleepRecoveryWorkflow(dbosCtx DBOSContext, duration time.Duration) (time.Duration, error) {
-	result, err := dbosCtx.Sleep(duration)
+	result, err := Sleep(dbosCtx, duration)
 	if err != nil {
 		return 0, err
 	}
@@ -2603,7 +2603,7 @@ func TestSleep(t *testing.T) {
 
 	t.Run("SleepCannotBeCalledOutsideWorkflow", func(t *testing.T) {
 		// Attempt to call Sleep outside of a workflow context
-		_, err := dbosCtx.Sleep(1 * time.Second)
+		_, err := Sleep(dbosCtx, 1*time.Second)
 		if err == nil {
 			t.Fatal("expected error when calling Sleep outside of workflow context, but got none")
 		}


### PR DESCRIPTION
This PR adds workflow management features usable by a "client context", that is, a DBOSContext object that is initialized but not launched. The benefits of doing so is being able to interact with DBOS workflows without having the process dequeue tasks, recover workflows, or run an admin server.

Features added:
- Resume workflow
- Fork workflow
- Enqueue workflow by name
- Add ability to dismiss output/input from list workflows

Because the registry is indexed by workflow FQN, we need to keep another map from workflow "custom" name to workflow FQN. This should have been tested in PR that added custom workflow names.