### PR TITLE
retract v1s

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,3 +28,8 @@ require (
 	golang.org/x/text v0.26.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract (
+	v1.0.0-alpha4
+	v1.0.0-alpha.3
+)


### PR DESCRIPTION
Go offers a module proxy which, by default, keeps for ever every version it ever cached.

We need to add a `retract` directive in our `go.mod` to exclude these. See
- https://proxy.golang.org/
- https://go.dev/ref/mod#go-mod-file-retract

Here's the list the proxy knows

```
curl https://proxy.golang.org/github.com/dbos-inc/dbos-transact-go/@v/list

v1.0.0-alpha.3
v0.5.0-alpha
v0.5.1-alpha
v1.0.0-alpha4
```